### PR TITLE
Fix underlying type in same package

### DIFF
--- a/_example/user.gen.go
+++ b/_example/user.gen.go
@@ -70,26 +70,30 @@ func (q userSelectSQL) ForUpdate() userSelectSQL {
 	return q
 }
 
-func (q userSelectSQL) ID(v uint64, exprs ...sqlla.Operator) userSelectSQL {
+func (q userSelectSQL) ID(v UserId, exprs ...sqlla.Operator) userSelectSQL {
 	var op sqlla.Operator
 	if len(exprs) == 0 {
 		op = sqlla.OpEqual
 	} else {
 		op = exprs[0]
 	}
-	where := sqlla.ExprUint64{Value: v, Op: op, Column: "`id`"}
+	where := sqlla.ExprUint64{Value: uint64(v), Op: op, Column: "`id`"}
 	q.where = append(q.where, where)
 	return q
 }
 
-func (q userSelectSQL) IDIn(vs ...uint64) userSelectSQL {
-	where := sqlla.ExprMultiUint64{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`id`"}
+func (q userSelectSQL) IDIn(vs ...UserId) userSelectSQL {
+	_vs := make([]uint64, 0, len(vs))
+	for _, v := range vs {
+		_vs = append(_vs, uint64(v))
+	}
+	where := sqlla.ExprMultiUint64{Values: _vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`id`"}
 	q.where = append(q.where, where)
 	return q
 }
 
 func (q userSelectSQL) PkColumn(pk int64, exprs ...sqlla.Operator) userSelectSQL {
-	v := uint64(pk)
+	v := UserId(pk)
 	return q.ID(v, exprs...)
 }
 
@@ -372,19 +376,19 @@ func (q userSQL) Update() userUpdateSQL {
 	}
 }
 
-func (q userUpdateSQL) SetID(v uint64) userUpdateSQL {
+func (q userUpdateSQL) SetID(v UserId) userUpdateSQL {
 	q.setMap["`id`"] = v
 	return q
 }
 
-func (q userUpdateSQL) WhereID(v uint64, exprs ...sqlla.Operator) userUpdateSQL {
+func (q userUpdateSQL) WhereID(v UserId, exprs ...sqlla.Operator) userUpdateSQL {
 	var op sqlla.Operator
 	if len(exprs) == 0 {
 		op = sqlla.OpEqual
 	} else {
 		op = exprs[0]
 	}
-	where := sqlla.ExprUint64{Value: v, Op: op, Column: "`id`"}
+	where := sqlla.ExprUint64{Value: uint64(v), Op: op, Column: "`id`"}
 	q.where = append(q.where, where)
 	return q
 }
@@ -548,7 +552,7 @@ func (q userSQL) Insert() userInsertSQL {
 	}
 }
 
-func (q userInsertSQL) ValueID(v uint64) userInsertSQL {
+func (q userInsertSQL) ValueID(v UserId) userInsertSQL {
 	q.setMap["`id`"] = v
 	return q
 }
@@ -643,20 +647,24 @@ func (q userSQL) Delete() userDeleteSQL {
 	}
 }
 
-func (q userDeleteSQL) ID(v uint64, exprs ...sqlla.Operator) userDeleteSQL {
+func (q userDeleteSQL) ID(v UserId, exprs ...sqlla.Operator) userDeleteSQL {
 	var op sqlla.Operator
 	if len(exprs) == 0 {
 		op = sqlla.OpEqual
 	} else {
 		op = exprs[0]
 	}
-	where := sqlla.ExprUint64{Value: v, Op: op, Column: "`id`"}
+	where := sqlla.ExprUint64{Value: uint64(v), Op: op, Column: "`id`"}
 	q.where = append(q.where, where)
 	return q
 }
 
-func (q userDeleteSQL) IDIn(vs ...uint64) userDeleteSQL {
-	where := sqlla.ExprMultiUint64{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`id`"}
+func (q userDeleteSQL) IDIn(vs ...UserId) userDeleteSQL {
+	_vs := make([]uint64, 0, len(vs))
+	for _, v := range vs {
+		_vs = append(_vs, uint64(v))
+	}
+	where := sqlla.ExprMultiUint64{Values: _vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`id`"}
 	q.where = append(q.where, where)
 	return q
 }

--- a/_example/user.go
+++ b/_example/user.go
@@ -11,9 +11,11 @@ import (
 //go:generate go run ../cmd/sqlla/main.go
 //go:generate genddl -outpath=./sqlite3.sql -driver=sqlite3
 
+type UserId uint64
+
 //+table: user
 type User struct {
-	Id        uint64         `db:"id,primarykey,autoincrement"`
+	Id        UserId         `db:"id,primarykey,autoincrement"`
 	Name      string         `db:"name"`
 	Age       sql.NullInt64  `db:"age"`
 	Rate      float64        `db:"rate,default=0"`

--- a/_example/user_test.go
+++ b/_example/user_test.go
@@ -73,7 +73,7 @@ func TestSelect__NullInt64(t *testing.T) {
 }
 
 func TestSelect__ForUpdate(t *testing.T) {
-	q := NewUserSQL().Select().ID(uint64(1)).ForUpdate()
+	q := NewUserSQL().Select().ID(UserId(1)).ForUpdate()
 	query, args, err := q.ToSql()
 	if err != nil {
 		t.Error("unexpected error:", err)
@@ -88,8 +88,8 @@ func TestSelect__ForUpdate(t *testing.T) {
 
 func TestSelect__Or(t *testing.T) {
 	q := NewUserSQL().Select().Or(
-		NewUserSQL().Select().ID(uint64(1)),
-		NewUserSQL().Select().ID(uint64(2)),
+		NewUserSQL().Select().ID(UserId(1)),
+		NewUserSQL().Select().ID(UserId(2)),
 	)
 	query, args, err := q.ToSql()
 	if err != nil {
@@ -127,7 +127,7 @@ func TestSelect__OrNull(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	q := NewUserSQL().Update().SetName("barbar").WhereID(uint64(1))
+	q := NewUserSQL().Update().SetName("barbar").WhereID(UserId(1))
 	query, args, err := q.ToSql()
 	if err != nil {
 		t.Error("unexpected error:", err)
@@ -264,7 +264,7 @@ func TestCRUD__WithSqlite3(t *testing.T) {
 		t.Error("empty id:", id)
 	}
 
-	query, args, err = NewUserSQL().Select().IDIn(uint64(1)).ToSql()
+	query, args, err = NewUserSQL().Select().IDIn(UserId(1)).ToSql()
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
@@ -286,7 +286,7 @@ func TestCRUD__WithSqlite3(t *testing.T) {
 		t.Error("unmatched id:", rescanID)
 	}
 
-	query, args, err = NewUserSQL().Update().WhereID(id).SetName("barbar").ToSql()
+	query, args, err = NewUserSQL().Update().WhereID(UserId(id)).SetName("barbar").ToSql()
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
@@ -318,7 +318,7 @@ func TestORM__WithSqlite3(t *testing.T) {
 	if err != nil {
 		t.Error("cannot insert row error:", err)
 	}
-	if insertedRow.Id == uint64(0) {
+	if insertedRow.Id == UserId(0) {
 		t.Error("empty id:", insertedRow.Id)
 	}
 	if insertedRow.Name != "hogehoge" {
@@ -329,7 +329,7 @@ func TestORM__WithSqlite3(t *testing.T) {
 	if err != nil {
 		t.Error("cannot select row error:", err)
 	}
-	if singleRow.Id == uint64(0) {
+	if singleRow.Id == UserId(0) {
 		t.Error("empty id:", singleRow.Id)
 	}
 	if singleRow.Name != "hogehoge" {
@@ -347,7 +347,7 @@ func TestORM__WithSqlite3(t *testing.T) {
 	}
 
 	for _, row := range rows {
-		if row.Id == uint64(0) {
+		if row.Id == UserId(0) {
 			t.Error("empty id:", row.Id)
 		}
 		if row.Name != "hogehoge" && row.Name != "fugafuga" {

--- a/table.go
+++ b/table.go
@@ -2,10 +2,12 @@ package sqlla
 
 import (
 	"go/ast"
+	"go/types"
 	"io"
 )
 
 type Table struct {
+	Package               *types.Package
 	PackageName           string
 	StructName            string
 	Name                  string
@@ -23,7 +25,9 @@ func (t *Table) AddColumn(c Column) {
 		t.PkColumn = &c
 	}
 	if c.PkgName != "" {
-		t.additionalPackagesMap[c.PkgName] = struct{}{}
+		if t.Package.Path() != c.PkgName {
+			t.additionalPackagesMap[c.PkgName] = struct{}{}
+		}
 	}
 	t.Columns = append(t.Columns, c)
 }


### PR DESCRIPTION
In https://github.com/mackee/go-sqlla/pull/13, when using a user-defined type defined in same package to table, cycle importing (self importing) was occurred.

So I fix it as the following.

- When use a user-defined type in same package,
    - don't add package prefix to type name
    - don't import package