### PR TITLE
add blocker in generator by go version

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -1,26 +1,14 @@
 package sqlla
 
 import (
-	"bytes"
-	"go/format"
+	"fmt"
 	"io"
+	"runtime"
 	"text/template"
-
-	"github.com/pkg/errors"
 )
 
 var tmpl = template.New("table")
 
 func WriteCode(w io.Writer, table *Table) error {
-	buf := new(bytes.Buffer)
-	err := tmpl.Execute(buf, table)
-	if err != nil {
-		return errors.Wrapf(err, "fail to render")
-	}
-	bs, err := format.Source(buf.Bytes())
-	if err != nil {
-		return errors.Wrapf(err, "fail to format")
-	}
-	_, err = w.Write(bs)
-	return err
+	return fmt.Errorf("must build by go version of 1.16 or higher. this built by %s", runtime.Version())
 }


### PR DESCRIPTION
In #13, using go:embed at the embedding templates. But this feature cannot use less than go 1.16.

So I implement a warning when using `sqlla` command built by the lower go version.