### PR TITLE
add feature: IN Operator at UPDATE

### DIFF
--- a/_example/user.gen.go
+++ b/_example/user.gen.go
@@ -393,6 +393,16 @@ func (q userUpdateSQL) WhereID(v UserId, exprs ...sqlla.Operator) userUpdateSQL 
 	return q
 }
 
+func (q userUpdateSQL) WhereIDIn(vs ...UserId) userUpdateSQL {
+	_vs := make([]uint64, 0, len(vs))
+	for _, v := range vs {
+		_vs = append(_vs, uint64(v))
+	}
+	where := sqlla.ExprMultiUint64{Values: _vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`id`"}
+	q.where = append(q.where, where)
+	return q
+}
+
 func (q userUpdateSQL) SetName(v string) userUpdateSQL {
 	q.setMap["`name`"] = v
 	return q
@@ -406,6 +416,12 @@ func (q userUpdateSQL) WhereName(v string, exprs ...sqlla.Operator) userUpdateSQ
 		op = exprs[0]
 	}
 	where := sqlla.ExprString{Value: v, Op: op, Column: "`name`"}
+	q.where = append(q.where, where)
+	return q
+}
+
+func (q userUpdateSQL) WhereNameIn(vs ...string) userUpdateSQL {
+	where := sqlla.ExprMultiString{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`name`"}
 	q.where = append(q.where, where)
 	return q
 }
@@ -427,6 +443,12 @@ func (q userUpdateSQL) WhereAge(v sql.NullInt64, exprs ...sqlla.Operator) userUp
 	return q
 }
 
+func (q userUpdateSQL) WhereAgeIn(vs ...sql.NullInt64) userUpdateSQL {
+	where := sqlla.ExprMultiNullInt64{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`age`"}
+	q.where = append(q.where, where)
+	return q
+}
+
 func (q userUpdateSQL) SetRate(v float64) userUpdateSQL {
 	q.setMap["`rate`"] = v
 	return q
@@ -440,6 +462,12 @@ func (q userUpdateSQL) WhereRate(v float64, exprs ...sqlla.Operator) userUpdateS
 		op = exprs[0]
 	}
 	where := sqlla.ExprFloat64{Value: v, Op: op, Column: "`rate`"}
+	q.where = append(q.where, where)
+	return q
+}
+
+func (q userUpdateSQL) WhereRateIn(vs ...float64) userUpdateSQL {
+	where := sqlla.ExprMultiFloat64{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`rate`"}
 	q.where = append(q.where, where)
 	return q
 }
@@ -461,6 +489,12 @@ func (q userUpdateSQL) WhereCreatedAt(v time.Time, exprs ...sqlla.Operator) user
 	return q
 }
 
+func (q userUpdateSQL) WhereCreatedAtIn(vs ...time.Time) userUpdateSQL {
+	where := sqlla.ExprMultiTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`created_at`"}
+	q.where = append(q.where, where)
+	return q
+}
+
 func (q userUpdateSQL) SetUpdatedAt(v mysql.NullTime) userUpdateSQL {
 	q.setMap["`updated_at`"] = v
 	return q
@@ -474,6 +508,12 @@ func (q userUpdateSQL) WhereUpdatedAt(v mysql.NullTime, exprs ...sqlla.Operator)
 		op = exprs[0]
 	}
 	where := sqlla.ExprNullTime{Value: v, Op: op, Column: "`updated_at`"}
+	q.where = append(q.where, where)
+	return q
+}
+
+func (q userUpdateSQL) WhereUpdatedAtIn(vs ...mysql.NullTime) userUpdateSQL {
+	where := sqlla.ExprMultiNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`updated_at`"}
 	q.where = append(q.where, where)
 	return q
 }

--- a/_example/user_item.gen.go
+++ b/_example/user_item.gen.go
@@ -388,6 +388,12 @@ func (q userItemUpdateSQL) WhereID(v uint64, exprs ...sqlla.Operator) userItemUp
 	return q
 }
 
+func (q userItemUpdateSQL) WhereIDIn(vs ...uint64) userItemUpdateSQL {
+	where := sqlla.ExprMultiUint64{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`id`"}
+	q.where = append(q.where, where)
+	return q
+}
+
 func (q userItemUpdateSQL) SetUserID(v uint64) userItemUpdateSQL {
 	q.setMap["`user_id`"] = v
 	return q
@@ -401,6 +407,12 @@ func (q userItemUpdateSQL) WhereUserID(v uint64, exprs ...sqlla.Operator) userIt
 		op = exprs[0]
 	}
 	where := sqlla.ExprUint64{Value: v, Op: op, Column: "`user_id`"}
+	q.where = append(q.where, where)
+	return q
+}
+
+func (q userItemUpdateSQL) WhereUserIDIn(vs ...uint64) userItemUpdateSQL {
+	where := sqlla.ExprMultiUint64{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`user_id`"}
 	q.where = append(q.where, where)
 	return q
 }
@@ -422,6 +434,12 @@ func (q userItemUpdateSQL) WhereItemID(v string, exprs ...sqlla.Operator) userIt
 	return q
 }
 
+func (q userItemUpdateSQL) WhereItemIDIn(vs ...string) userItemUpdateSQL {
+	where := sqlla.ExprMultiString{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`item_id`"}
+	q.where = append(q.where, where)
+	return q
+}
+
 func (q userItemUpdateSQL) SetIsUsed(v bool) userItemUpdateSQL {
 	q.setMap["`is_used`"] = v
 	return q
@@ -435,6 +453,12 @@ func (q userItemUpdateSQL) WhereIsUsed(v bool, exprs ...sqlla.Operator) userItem
 		op = exprs[0]
 	}
 	where := sqlla.ExprBool{Value: v, Op: op, Column: "`is_used`"}
+	q.where = append(q.where, where)
+	return q
+}
+
+func (q userItemUpdateSQL) WhereIsUsedIn(vs ...bool) userItemUpdateSQL {
+	where := sqlla.ExprMultiBool{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`is_used`"}
 	q.where = append(q.where, where)
 	return q
 }
@@ -456,6 +480,12 @@ func (q userItemUpdateSQL) WhereHasExtension(v sql.NullBool, exprs ...sqlla.Oper
 	return q
 }
 
+func (q userItemUpdateSQL) WhereHasExtensionIn(vs ...sql.NullBool) userItemUpdateSQL {
+	where := sqlla.ExprMultiNullBool{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`has_extension`"}
+	q.where = append(q.where, where)
+	return q
+}
+
 func (q userItemUpdateSQL) SetUsedAt(v mysql.NullTime) userItemUpdateSQL {
 	q.setMap["`used_at`"] = v
 	return q
@@ -469,6 +499,12 @@ func (q userItemUpdateSQL) WhereUsedAt(v mysql.NullTime, exprs ...sqlla.Operator
 		op = exprs[0]
 	}
 	where := sqlla.ExprNullTime{Value: v, Op: op, Column: "`used_at`"}
+	q.where = append(q.where, where)
+	return q
+}
+
+func (q userItemUpdateSQL) WhereUsedAtIn(vs ...mysql.NullTime) userItemUpdateSQL {
+	where := sqlla.ExprMultiNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`used_at`"}
 	q.where = append(q.where, where)
 	return q
 }

--- a/_example/user_test.go
+++ b/_example/user_test.go
@@ -152,6 +152,37 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestUpdate__InOperator(t *testing.T) {
+	q := NewUserSQL().Update().SetRate(42).WhereIDIn(UserId(1), UserId(2), UserId(3))
+	query, args, err := q.ToSql()
+	if err != nil {
+		t.Error("unexpected error:", err)
+	}
+	switch query {
+	case "UPDATE user SET `rate` = ?, `updated_at` = ? WHERE `id` IN(?,?,?);":
+		if !reflect.DeepEqual(args[0], float64(42)) {
+			t.Errorf("unexpected args: %+v", args[0])
+		}
+		for i, v := range []uint64{1, 2, 3} {
+			if !reflect.DeepEqual(args[2+i], v) {
+				t.Errorf("unexpected args: i=%d, %+v", i, args[2:])
+			}
+		}
+	case "UPDATE user SET `updated_at` = ?, `rate` = ? WHERE `id` IN(?,?,?);":
+		if !reflect.DeepEqual(args[1], float64(42)) {
+			t.Errorf("unexpected args: %+v", args[1])
+		}
+		for i, v := range []uint64{1, 2, 3} {
+			if !reflect.DeepEqual(args[2+i], v) {
+				t.Errorf("unexpected args: i=%d, %+v", i, args[2:])
+			}
+		}
+	default:
+		t.Error("unexpected query:", query)
+	}
+
+}
+
 func TestInsert(t *testing.T) {
 	q := NewUserSQL().Insert().ValueName("hogehoge")
 	query, args, err := q.ToSql()

--- a/template/update_column.tmpl
+++ b/template/update_column.tmpl
@@ -21,4 +21,17 @@ func (q {{ $smallTableName }}UpdateSQL) Where{{ .Name | toCamel | Title }}(v {{ 
 	return q
 }
 
+func (q {{ $smallTableName }}UpdateSQL) Where{{ .Name | toCamel | Title }}In(vs ...{{ .TypeName }}) {{ $smallTableName }}UpdateSQL {
+{{- if ne .BaseTypeName .TypeName }}
+	_vs := make([]{{ .BaseTypeName }}, 0, len(vs))
+	for _, v := range vs {
+		_vs = append(_vs, {{ .BaseTypeName }}(v))
+	}
+	where := sqlla.ExprMulti{{ .BaseTypeName | Exprize | Title }}{Values: _vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`{{ .Name }}`"}
+{{- else }}
+	where := sqlla.ExprMulti{{ .BaseTypeName | Exprize | Title }}{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`{{ .Name }}`"}
+{{- end }}
+	q.where = append(q.where, where)
+	return q
+}
 {{ end }}


### PR DESCRIPTION
### Usecase

* UPDATE multi rows

### Usage

Schema
```go
//+table: item
type Item struct {
    ID int64 `db:"id"`
    Name string `db:"name"`
    Amount int64 `db:"amount"`
}
```

At the schema, if you want to update to amount `10` on multi rows that ID is 1, 2, and 3:

```go
rows, err := NewItemSQL().Update().
    SetAmount(10).
    WhereIDIn(1, 2, 3).
    ExecContext(ctx, db)
```