### PR TITLE
add a feature to support sql.NullTime

### DIFF
--- a/_example/user.gen.go
+++ b/_example/user.gen.go
@@ -261,13 +261,13 @@ func (q userSelectSQL) UpdatedAt(v mysql.NullTime, exprs ...sqlla.Operator) user
 	} else {
 		op = exprs[0]
 	}
-	where := sqlla.ExprNullTime{Value: v, Op: op, Column: "`updated_at`"}
+	where := sqlla.ExprMysqlNullTime{Value: v, Op: op, Column: "`updated_at`"}
 	q.where = append(q.where, where)
 	return q
 }
 
 func (q userSelectSQL) UpdatedAtIn(vs ...mysql.NullTime) userSelectSQL {
-	where := sqlla.ExprMultiNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`updated_at`"}
+	where := sqlla.ExprMultiMysqlNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`updated_at`"}
 	q.where = append(q.where, where)
 	return q
 }
@@ -561,13 +561,13 @@ func (q userUpdateSQL) WhereUpdatedAt(v mysql.NullTime, exprs ...sqlla.Operator)
 	} else {
 		op = exprs[0]
 	}
-	where := sqlla.ExprNullTime{Value: v, Op: op, Column: "`updated_at`"}
+	where := sqlla.ExprMysqlNullTime{Value: v, Op: op, Column: "`updated_at`"}
 	q.where = append(q.where, where)
 	return q
 }
 
 func (q userUpdateSQL) WhereUpdatedAtIn(vs ...mysql.NullTime) userUpdateSQL {
-	where := sqlla.ExprMultiNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`updated_at`"}
+	where := sqlla.ExprMultiMysqlNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`updated_at`"}
 	q.where = append(q.where, where)
 	return q
 }
@@ -1127,13 +1127,13 @@ func (q userDeleteSQL) UpdatedAt(v mysql.NullTime, exprs ...sqlla.Operator) user
 	} else {
 		op = exprs[0]
 	}
-	where := sqlla.ExprNullTime{Value: v, Op: op, Column: "`updated_at`"}
+	where := sqlla.ExprMysqlNullTime{Value: v, Op: op, Column: "`updated_at`"}
 	q.where = append(q.where, where)
 	return q
 }
 
 func (q userDeleteSQL) UpdatedAtIn(vs ...mysql.NullTime) userDeleteSQL {
-	where := sqlla.ExprMultiNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`updated_at`"}
+	where := sqlla.ExprMultiMysqlNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`updated_at`"}
 	q.where = append(q.where, where)
 	return q
 }

--- a/_example/user_item.gen.go
+++ b/_example/user_item.gen.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"database/sql"
-	"github.com/go-sql-driver/mysql"
 
 	"github.com/mackee/go-sqlla/v2"
 )
@@ -220,7 +219,7 @@ func (q userItemSelectSQL) OrderByHasExtension(order sqlla.Order) userItemSelect
 	return q
 }
 
-func (q userItemSelectSQL) UsedAt(v mysql.NullTime, exprs ...sqlla.Operator) userItemSelectSQL {
+func (q userItemSelectSQL) UsedAt(v sql.NullTime, exprs ...sqlla.Operator) userItemSelectSQL {
 	var op sqlla.Operator
 	if len(exprs) == 0 {
 		op = sqlla.OpEqual
@@ -232,7 +231,7 @@ func (q userItemSelectSQL) UsedAt(v mysql.NullTime, exprs ...sqlla.Operator) use
 	return q
 }
 
-func (q userItemSelectSQL) UsedAtIn(vs ...mysql.NullTime) userItemSelectSQL {
+func (q userItemSelectSQL) UsedAtIn(vs ...sql.NullTime) userItemSelectSQL {
 	where := sqlla.ExprMultiNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`used_at`"}
 	q.where = append(q.where, where)
 	return q
@@ -487,12 +486,12 @@ func (q userItemUpdateSQL) WhereHasExtensionIn(vs ...sql.NullBool) userItemUpdat
 	return q
 }
 
-func (q userItemUpdateSQL) SetUsedAt(v mysql.NullTime) userItemUpdateSQL {
+func (q userItemUpdateSQL) SetUsedAt(v sql.NullTime) userItemUpdateSQL {
 	q.setMap["`used_at`"] = v
 	return q
 }
 
-func (q userItemUpdateSQL) WhereUsedAt(v mysql.NullTime, exprs ...sqlla.Operator) userItemUpdateSQL {
+func (q userItemUpdateSQL) WhereUsedAt(v sql.NullTime, exprs ...sqlla.Operator) userItemUpdateSQL {
 	var op sqlla.Operator
 	if len(exprs) == 0 {
 		op = sqlla.OpEqual
@@ -504,7 +503,7 @@ func (q userItemUpdateSQL) WhereUsedAt(v mysql.NullTime, exprs ...sqlla.Operator
 	return q
 }
 
-func (q userItemUpdateSQL) WhereUsedAtIn(vs ...mysql.NullTime) userItemUpdateSQL {
+func (q userItemUpdateSQL) WhereUsedAtIn(vs ...sql.NullTime) userItemUpdateSQL {
 	where := sqlla.ExprMultiNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`used_at`"}
 	q.where = append(q.where, where)
 	return q
@@ -609,7 +608,7 @@ func (q userItemInsertSQL) ValueHasExtension(v sql.NullBool) userItemInsertSQL {
 	return q
 }
 
-func (q userItemInsertSQL) ValueUsedAt(v mysql.NullTime) userItemInsertSQL {
+func (q userItemInsertSQL) ValueUsedAt(v sql.NullTime) userItemInsertSQL {
 	q.setMap["`used_at`"] = v
 	return q
 }
@@ -777,7 +776,7 @@ func (q userItemInsertOnDuplicateKeyUpdateSQL) SameOnUpdateHasExtension() userIt
 	return q
 }
 
-func (q userItemInsertOnDuplicateKeyUpdateSQL) ValueOnUpdateUsedAt(v mysql.NullTime) userItemInsertOnDuplicateKeyUpdateSQL {
+func (q userItemInsertOnDuplicateKeyUpdateSQL) ValueOnUpdateUsedAt(v sql.NullTime) userItemInsertOnDuplicateKeyUpdateSQL {
 	q.onDuplicateKeyUpdateMap["`used_at`"] = v
 	return q
 }
@@ -1016,7 +1015,7 @@ func (q userItemDeleteSQL) HasExtensionIn(vs ...sql.NullBool) userItemDeleteSQL 
 	return q
 }
 
-func (q userItemDeleteSQL) UsedAt(v mysql.NullTime, exprs ...sqlla.Operator) userItemDeleteSQL {
+func (q userItemDeleteSQL) UsedAt(v sql.NullTime, exprs ...sqlla.Operator) userItemDeleteSQL {
 	var op sqlla.Operator
 	if len(exprs) == 0 {
 		op = sqlla.OpEqual
@@ -1028,7 +1027,7 @@ func (q userItemDeleteSQL) UsedAt(v mysql.NullTime, exprs ...sqlla.Operator) use
 	return q
 }
 
-func (q userItemDeleteSQL) UsedAtIn(vs ...mysql.NullTime) userItemDeleteSQL {
+func (q userItemDeleteSQL) UsedAtIn(vs ...sql.NullTime) userItemDeleteSQL {
 	where := sqlla.ExprMultiNullTime{Values: vs, Op: sqlla.MakeInOperator(len(vs)), Column: "`used_at`"}
 	q.where = append(q.where, where)
 	return q

--- a/_example/user_item.go
+++ b/_example/user_item.go
@@ -2,18 +2,16 @@ package example
 
 import (
 	"database/sql"
-
-	"github.com/go-sql-driver/mysql"
 )
 
 //go:generate go run ../cmd/sqlla/main.go
 
 //+table: user_item
 type UserItem struct {
-	Id           uint64         `db:"id,primarykey,autoincrement"`
-	UserId       uint64         `db:"user_id"`
-	ItemId       string         `db:"item_id"`
-	IsUsed       bool           `db:"is_used"`
-	HasExtension sql.NullBool   `db:"has_extension"`
-	UsedAt       mysql.NullTime `db:"used_at"`
+	Id           uint64       `db:"id,primarykey,autoincrement"`
+	UserId       uint64       `db:"user_id"`
+	ItemId       string       `db:"item_id"`
+	IsUsed       bool         `db:"is_used"`
+	HasExtension sql.NullBool `db:"has_extension"`
+	UsedAt       sql.NullTime `db:"used_at"`
 }

--- a/_example/user_test.go
+++ b/_example/user_test.go
@@ -108,11 +108,11 @@ func TestSelect__Or(t *testing.T) {
 
 func TestSelect__OrNull(t *testing.T) {
 	now := time.Now()
-	nt := mysql.NullTime{Time: now, Valid: true}
+	nt := sql.NullTime{Time: now, Valid: true}
 	q := NewUserItemSQL().Select().
 		IDIn(uint64(1), uint64(2)).
 		Or(
-			NewUserItemSQL().Select().UsedAt(mysql.NullTime{}, sqlla.OpIs),
+			NewUserItemSQL().Select().UsedAt(sql.NullTime{}, sqlla.OpIs),
 			NewUserItemSQL().Select().UsedAt(nt, sqlla.OpLess),
 		)
 	query, args, err := q.ToSql()
@@ -258,7 +258,7 @@ func TestBulkInsertWithOnDuplicateKeyUpdate(t *testing.T) {
 		NewUserItemSQL().Insert().ValueUserID(42).ValueItemID("2").ValueIsUsed(true),
 	)
 
-	now := mysql.NullTime{
+	now := sql.NullTime{
 		Valid: true,
 		Time:  time.Now(),
 	}

--- a/cmd/mysql2schema/main.go
+++ b/cmd/mysql2schema/main.go
@@ -242,7 +242,7 @@ func sqlTypeToSchemaType(c Column) (string, error) {
 		return "string", nil
 	case strings.HasPrefix(c.Type, "datetime"):
 		if c.IsNull {
-			return "mysql.NullTime", nil
+			return "sql.NullTime", nil
 		}
 		return "time.Time", nil
 	default:

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func Run(from, ext string) {
 var supportedNonPrimitiveTypes = map[string]struct{}{
 	"time.Time":       {},
 	"mysql.NullTime":  {},
+	"sql.NullTime":    {},
 	"sql.NullInt64":   {},
 	"sql.NullString":  {},
 	"sql.NullFloat64": {},
@@ -80,7 +81,8 @@ var supportedNonPrimitiveTypes = map[string]struct{}{
 }
 
 var altTypeNames = map[string]string{
-	"[]byte": "Bytes",
+	"[]byte":         "Bytes",
+	"mysql.NullTime": "MysqlNullTime",
 }
 
 func toTable(tablePkg *types.Package, annotationComment string, gd *ast.GenDecl, ti *types.Info) (*Table, error) {


### PR DESCRIPTION
go-sql-driver/mysql.NullTime is deprecated. So some linter(Ex. staticcheck) has warnings the code that uses it.

Therefore, the sqlla will be deprecated `mysql.NullTime` near future. This PR adds sql.NullTime support because of preparation to deprecation.

## Breaking changes

These changes have not changed behavior. But changes generation code for `mysql.NullTime`.