### PR TITLE
add feature: "<column> IS NOT NULL" at SELECT WHERE

### DIFF
--- a/_example/user_test.go
+++ b/_example/user_test.go
@@ -74,6 +74,20 @@ func TestSelect__NullInt64(t *testing.T) {
 	}
 }
 
+func TestSelect__NullInt64__IsNotNull(t *testing.T) {
+	q := NewUserSQL().Select().Age(sql.NullInt64{}, sqlla.OpNot)
+	query, args, err := q.ToSql()
+	if err != nil {
+		t.Error("unexpected error:", err)
+	}
+	if query != "SELECT "+columns+" FROM user WHERE `age` IS NOT NULL;" {
+		t.Error("unexpected query:", query)
+	}
+	if !reflect.DeepEqual(args, []interface{}{}) {
+		t.Error("unexpected args:", args)
+	}
+}
+
 func TestSelect__ForUpdate(t *testing.T) {
 	q := NewUserSQL().Select().ID(UserId(1)).ForUpdate()
 	query, args, err := q.ToSql()

--- a/expr.go
+++ b/expr.go
@@ -156,7 +156,11 @@ func (e ExprNullInt64) ToSql() (string, []interface{}, error) {
 	var err error
 	vs := []interface{}{}
 	if !e.Value.Valid {
-		ops, err = OpIsNull.ToSql()
+		if e.Op == OpNot {
+			ops, err = OpIsNotNull.ToSql()
+		} else {
+			ops, err = OpIsNull.ToSql()
+		}
 	} else {
 		ops, err = e.Op.ToSql()
 		placeholder = " ?"
@@ -198,7 +202,11 @@ func (e ExprNullString) ToSql() (string, []interface{}, error) {
 	var err error
 	vs := []interface{}{}
 	if !e.Value.Valid {
-		ops, err = OpIsNull.ToSql()
+		if e.Op == OpNot {
+			ops, err = OpIsNotNull.ToSql()
+		} else {
+			ops, err = OpIsNull.ToSql()
+		}
 	} else {
 		ops, err = e.Op.ToSql()
 		placeholder = " ?"
@@ -304,7 +312,11 @@ func (e ExprNullTime) ToSql() (string, []interface{}, error) {
 	var err error
 	vs := []interface{}{}
 	if !e.Value.Valid {
-		ops, err = OpIsNull.ToSql()
+		if e.Op == OpNot {
+			ops, err = OpIsNotNull.ToSql()
+		} else {
+			ops, err = OpIsNull.ToSql()
+		}
 	} else {
 		ops, err = e.Op.ToSql()
 		placeholder = " ?"
@@ -346,7 +358,11 @@ func (e ExprMysqlNullTime) ToSql() (string, []interface{}, error) {
 	var err error
 	vs := []interface{}{}
 	if !e.Value.Valid {
-		ops, err = OpIsNull.ToSql()
+		if e.Op == OpNot {
+			ops, err = OpIsNotNull.ToSql()
+		} else {
+			ops, err = OpIsNull.ToSql()
+		}
 	} else {
 		ops, err = e.Op.ToSql()
 		placeholder = " ?"
@@ -388,7 +404,11 @@ func (e ExprNullFloat64) ToSql() (string, []interface{}, error) {
 	var err error
 	vs := []interface{}{}
 	if !e.Value.Valid {
-		ops, err = OpIsNull.ToSql()
+		if e.Op == OpNot {
+			ops, err = OpIsNotNull.ToSql()
+		} else {
+			ops, err = OpIsNull.ToSql()
+		}
 	} else {
 		ops, err = e.Op.ToSql()
 		placeholder = " ?"
@@ -462,7 +482,11 @@ func (e ExprNullBool) ToSql() (string, []interface{}, error) {
 	var err error
 	vs := []interface{}{}
 	if !e.Value.Valid {
-		ops, err = OpIsNull.ToSql()
+		if e.Op == OpNot {
+			ops, err = OpIsNotNull.ToSql()
+		} else {
+			ops, err = OpIsNull.ToSql()
+		}
 	} else {
 		ops, err = e.Op.ToSql()
 		placeholder = " ?"

--- a/expr.go
+++ b/expr.go
@@ -157,9 +157,9 @@ func (e ExprNullInt64) ToSql() (string, []interface{}, error) {
 	vs := []interface{}{}
 	if !e.Value.Valid {
 		if e.Op == OpNot {
-			ops, err = OpIsNotNull.ToSql()
+			ops, err = opIsNotNull.ToSql()
 		} else {
-			ops, err = OpIsNull.ToSql()
+			ops, err = opIsNull.ToSql()
 		}
 	} else {
 		ops, err = e.Op.ToSql()
@@ -203,9 +203,9 @@ func (e ExprNullString) ToSql() (string, []interface{}, error) {
 	vs := []interface{}{}
 	if !e.Value.Valid {
 		if e.Op == OpNot {
-			ops, err = OpIsNotNull.ToSql()
+			ops, err = opIsNotNull.ToSql()
 		} else {
-			ops, err = OpIsNull.ToSql()
+			ops, err = opIsNull.ToSql()
 		}
 	} else {
 		ops, err = e.Op.ToSql()
@@ -313,9 +313,9 @@ func (e ExprNullTime) ToSql() (string, []interface{}, error) {
 	vs := []interface{}{}
 	if !e.Value.Valid {
 		if e.Op == OpNot {
-			ops, err = OpIsNotNull.ToSql()
+			ops, err = opIsNotNull.ToSql()
 		} else {
-			ops, err = OpIsNull.ToSql()
+			ops, err = opIsNull.ToSql()
 		}
 	} else {
 		ops, err = e.Op.ToSql()
@@ -359,9 +359,9 @@ func (e ExprMysqlNullTime) ToSql() (string, []interface{}, error) {
 	vs := []interface{}{}
 	if !e.Value.Valid {
 		if e.Op == OpNot {
-			ops, err = OpIsNotNull.ToSql()
+			ops, err = opIsNotNull.ToSql()
 		} else {
-			ops, err = OpIsNull.ToSql()
+			ops, err = opIsNull.ToSql()
 		}
 	} else {
 		ops, err = e.Op.ToSql()
@@ -405,9 +405,9 @@ func (e ExprNullFloat64) ToSql() (string, []interface{}, error) {
 	vs := []interface{}{}
 	if !e.Value.Valid {
 		if e.Op == OpNot {
-			ops, err = OpIsNotNull.ToSql()
+			ops, err = opIsNotNull.ToSql()
 		} else {
-			ops, err = OpIsNull.ToSql()
+			ops, err = opIsNull.ToSql()
 		}
 	} else {
 		ops, err = e.Op.ToSql()
@@ -483,9 +483,9 @@ func (e ExprNullBool) ToSql() (string, []interface{}, error) {
 	vs := []interface{}{}
 	if !e.Value.Valid {
 		if e.Op == OpNot {
-			ops, err = OpIsNotNull.ToSql()
+			ops, err = opIsNotNull.ToSql()
 		} else {
-			ops, err = OpIsNull.ToSql()
+			ops, err = opIsNull.ToSql()
 		}
 	} else {
 		ops, err = e.Op.ToSql()

--- a/operator.go
+++ b/operator.go
@@ -12,8 +12,8 @@ var (
 	OpLessEqual    Operator = "<="
 	OpNot          Operator = "<>"
 	OpIs           Operator = "IS"
-	OpIsNull       Operator = "IS NULL"
-	OpIsNotNull    Operator = "IS NOT NULL"
+	opIsNull       Operator = "IS NULL"
+	opIsNotNull    Operator = "IS NOT NULL"
 )
 
 type Operator string

--- a/operator.go
+++ b/operator.go
@@ -13,6 +13,7 @@ var (
 	OpNot          Operator = "<>"
 	OpIs           Operator = "IS"
 	OpIsNull       Operator = "IS NULL"
+	OpIsNotNull    Operator = "IS NOT NULL"
 )
 
 type Operator string


### PR DESCRIPTION
Support `IS NOT NULL` at SELECT * WHERE ~.

### Example

#### Schema

```go
//+table: foobar 
type Foobar struct {
    Num sql.NullInt64 `db:"num"`
}
```

#### Code

```go
NewFoobarSQL().Select().Num(sql.NullInt64{}, sqlla.OpNot).ToSql()
// SELECT num FROM foobar WHERE num IS NOT NULL;
```

#### Note

This PR contains breaking changes but old behavior looks like bugly for me. 