### PR TITLE
add: support new annotation for go1.19

### DIFF
--- a/_example/user.go
+++ b/_example/user.go
@@ -13,7 +13,7 @@ import (
 
 type UserId uint64
 
-//+table: user
+// +table: user
 type User struct {
 	Id        UserId         `db:"id,primarykey,autoincrement"`
 	Name      string         `db:"name"`

--- a/_example/user_external.go
+++ b/_example/user_external.go
@@ -4,7 +4,7 @@ import "time"
 
 //go:generate go run ../cmd/sqlla/main.go
 
-//+table: user_external
+// +table: user_external
 type UserExternal struct {
 	Id        uint64    `db:"id,primarykey"`
 	UserId    uint64    `db:"user_id"`

--- a/_example/user_item.go
+++ b/_example/user_item.go
@@ -6,7 +6,7 @@ import (
 
 //go:generate go run ../cmd/sqlla/main.go
 
-//+table: user_item
+// +table: user_item
 type UserItem struct {
 	Id           uint64       `db:"id,primarykey,autoincrement"`
 	UserId       uint64       `db:"user_id"`

--- a/cmd/mysql2schema/main.go
+++ b/cmd/mysql2schema/main.go
@@ -175,7 +175,7 @@ func outputSchema(db *sql.DB, table string, out io.Writer) error {
 	}
 
 	outBuf := new(bytes.Buffer)
-	outBuf.WriteString("//+table: " + table + "\n")
+	outBuf.WriteString("// +table: " + table + "\n")
 	outBuf.WriteString("type ")
 	outBuf.WriteString(snaker.SnakeToCamel(table))
 	outBuf.WriteString(" struct {\n")

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func Run(from, ext string) {
 				var hasAnnotation bool
 				var annotationComment string
 				for _, comment := range genDecl.Doc.List {
-					if strings.HasPrefix(comment.Text, "//+table:") {
+					if trimmed := trimAnnotation(comment.Text); trimmed != comment.Text {
 						hasAnnotation = true
 						annotationComment = comment.Text
 						break
@@ -90,7 +90,7 @@ func toTable(tablePkg *types.Package, annotationComment string, gd *ast.GenDecl,
 	table.Package = tablePkg
 	table.PackageName = tablePkg.Name()
 
-	tableName := strings.TrimPrefix(annotationComment, "//+table: ")
+	tableName := trimAnnotation(annotationComment)
 	table.Name = tableName
 
 	spec := gd.Specs[0]
@@ -154,4 +154,17 @@ func toTable(tablePkg *types.Package, annotationComment string, gd *ast.GenDecl,
 	}
 
 	return table, nil
+}
+
+func trimAnnotation(comment string) string {
+	if trimmed := strings.TrimPrefix(comment, "//+table:"); trimmed != comment {
+		return trimmed
+	}
+	if trimmed := strings.TrimPrefix(comment, "// +table:"); trimmed != comment {
+		return trimmed
+	}
+	if trimmed := strings.TrimPrefix(comment, "//sqlla:table "); trimmed != comment {
+		return trimmed
+	}
+	return comment
 }

--- a/main.go
+++ b/main.go
@@ -157,14 +157,11 @@ func toTable(tablePkg *types.Package, annotationComment string, gd *ast.GenDecl,
 }
 
 func trimAnnotation(comment string) string {
-	if trimmed := strings.TrimPrefix(comment, "//+table: "); trimmed != comment {
-		return trimmed
-	}
-	if trimmed := strings.TrimPrefix(comment, "// +table: "); trimmed != comment {
-		return trimmed
-	}
-	if trimmed := strings.TrimPrefix(comment, "//sqlla:table "); trimmed != comment {
-		return trimmed
+	prefixies := []string{"//+table: ", "// +table: ", "//sqlla:table "}
+	for _, prefix := range prefixies {
+		if trimmed := strings.TrimPrefix(comment, prefix); trimmed != comment {
+			return trimmed
+		}
 	}
 	return comment
 }

--- a/main.go
+++ b/main.go
@@ -157,10 +157,10 @@ func toTable(tablePkg *types.Package, annotationComment string, gd *ast.GenDecl,
 }
 
 func trimAnnotation(comment string) string {
-	if trimmed := strings.TrimPrefix(comment, "//+table:"); trimmed != comment {
+	if trimmed := strings.TrimPrefix(comment, "//+table: "); trimmed != comment {
 		return trimmed
 	}
-	if trimmed := strings.TrimPrefix(comment, "// +table:"); trimmed != comment {
+	if trimmed := strings.TrimPrefix(comment, "// +table: "); trimmed != comment {
 		return trimmed
 	}
 	if trimmed := strings.TrimPrefix(comment, "//sqlla:table "); trimmed != comment {

--- a/main.go
+++ b/main.go
@@ -157,8 +157,8 @@ func toTable(tablePkg *types.Package, annotationComment string, gd *ast.GenDecl,
 }
 
 func trimAnnotation(comment string) string {
-	prefixies := []string{"//+table: ", "// +table: ", "//sqlla:table "}
-	for _, prefix := range prefixies {
+	prefixes := []string{"//+table: ", "// +table: ", "//sqlla:table "}
+	for _, prefix := range prefixes {
 		if trimmed := strings.TrimPrefix(comment, prefix); trimmed != comment {
 			return trimmed
 		}


### PR DESCRIPTION
### Background

* `go fmt` now includes spaces in comments on go1.19.

### Solution

* Support annotation now that a `// +table: <table name>`.
* Support annotation yet that a `//+table: <table name>` for backward compatibility.
* Support annotation now that a `//sqlla:table`. It is for usecase of a definition that is different (ex. a subset) from the genddl.