### PR TITLE
fix: add char to `sqlTypeToSchemaType`

### DIFF
--- a/cmd/mysql2schema/main.go
+++ b/cmd/mysql2schema/main.go
@@ -235,7 +235,7 @@ func sqlTypeToSchemaType(c Column) (string, error) {
 			return "uint8", nil
 		}
 		return "int8", nil
-	case strings.HasPrefix(c.Type, "varchar"), strings.HasPrefix(c.Type, "text"), strings.HasPrefix(c.Type, "json"):
+	case strings.HasPrefix(c.Type, "char"), strings.HasPrefix(c.Type, "varchar"), strings.HasPrefix(c.Type, "text"), strings.HasPrefix(c.Type, "json"):
 		if c.IsNull {
 			return "sql.NullString", nil
 		}


### PR DESCRIPTION
I want to generate struct from table which has char type.

```sh
> mysql2schema -dsn "user:password@tcp(localhost:3306)/db" test
2022/11/09 22:33:44 failed output source in test: unexpected column type: {Name:id Type:char(8) IsUnsigned:false IsNull:false IsPk:true}
```