### PR TITLE
remove "ALPHA QUALITY" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # go-sqlla
 Type safe, reflect free, generative SQL Builder
 
-**THIS IS AN ALPHA QUALITY RELEASE. API MAY CHANGE WITHOUT NOTICE.**
-
 ## INSTALL
 
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Type safe, reflect free, generative SQL Builder
 ## INSTALL
 
 ```
-$ go get github.com/mackee/go-sqlla/v2/cmd/sqlla@latest
+$ go install github.com/mackee/go-sqlla/v2/cmd/sqlla@latest
 ```
 
 ## SYNOPSIS


### PR DESCRIPTION
Reason: To already widely used the sqlla in production.

Also, fix the installation command in document.