### PR TITLE
fix: enclose table names in backquote

### DIFF
--- a/_benchmark/vssquirrel_test.go
+++ b/_benchmark/vssquirrel_test.go
@@ -27,7 +27,7 @@ func TestSelect__Squirrel(t *testing.T) {
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
-	if query != "SELECT id, name FROM user WHERE name = ?" {
+	if query != "SELECT id, name FROM `user` WHERE name = ?" {
 		t.Fatal("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{"hogehoge"}) {
@@ -41,7 +41,7 @@ func TestSelect__Sqlla(t *testing.T) {
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
-	if query != "SELECT id, name FROM user WHERE name = ?;" {
+	if query != "SELECT id, name FROM `user` WHERE name = ?;" {
 		t.Fatal("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{"hogehoge"}) {

--- a/_example/user.gen.go
+++ b/_example/user.gen.go
@@ -350,7 +350,7 @@ func (q userSelectSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	tableName := "user"
+	tableName := "`user`"
 	if q.tableAlias != "" {
 		tableName = tableName + " AS " + q.tableAlias
 		pcs := make([]string, 0, len(q.Columns))
@@ -677,7 +677,7 @@ func (q userUpdateSQL) ToSql() (string, []interface{}, error) {
 		return "", []interface{}{}, err
 	}
 
-	query := "UPDATE user SET" + setColumns
+	query := "UPDATE `user` SET" + setColumns
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}
@@ -790,7 +790,7 @@ func (q userInsertSQL) userInsertSQLToSql() (string, []interface{}, error) {
 		return "", []interface{}{}, err
 	}
 
-	query := "INSERT INTO user " + qs
+	query := "INSERT INTO `user` " + qs
 
 	return query, vs, nil
 }
@@ -1231,7 +1231,7 @@ func (q userDeleteSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	query := "DELETE FROM user"
+	query := "DELETE FROM `user`"
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}

--- a/_example/user_external.gen.go
+++ b/_example/user_external.gen.go
@@ -287,7 +287,7 @@ func (q userExternalSelectSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	tableName := "user_external"
+	tableName := "`user_external`"
 	if q.tableAlias != "" {
 		tableName = tableName + " AS " + q.tableAlias
 		pcs := make([]string, 0, len(q.Columns))
@@ -562,7 +562,7 @@ func (q userExternalUpdateSQL) ToSql() (string, []interface{}, error) {
 		return "", []interface{}{}, err
 	}
 
-	query := "UPDATE user_external SET" + setColumns
+	query := "UPDATE `user_external` SET" + setColumns
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}
@@ -665,7 +665,7 @@ func (q userExternalInsertSQL) userExternalInsertSQLToSql() (string, []interface
 		return "", []interface{}{}, err
 	}
 
-	query := "INSERT INTO user_external " + qs
+	query := "INSERT INTO `user_external` " + qs
 
 	return query, vs, nil
 }
@@ -1036,7 +1036,7 @@ func (q userExternalDeleteSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	query := "DELETE FROM user_external"
+	query := "DELETE FROM `user_external`"
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}

--- a/_example/user_item.gen.go
+++ b/_example/user_item.gen.go
@@ -315,7 +315,7 @@ func (q userItemSelectSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	tableName := "user_item"
+	tableName := "`user_item`"
 	if q.tableAlias != "" {
 		tableName = tableName + " AS " + q.tableAlias
 		pcs := make([]string, 0, len(q.Columns))
@@ -614,7 +614,7 @@ func (q userItemUpdateSQL) ToSql() (string, []interface{}, error) {
 		return "", []interface{}{}, err
 	}
 
-	query := "UPDATE user_item SET" + setColumns
+	query := "UPDATE `user_item` SET" + setColumns
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}
@@ -722,7 +722,7 @@ func (q userItemInsertSQL) userItemInsertSQLToSql() (string, []interface{}, erro
 		return "", []interface{}{}, err
 	}
 
-	query := "INSERT INTO user_item " + qs
+	query := "INSERT INTO `user_item` " + qs
 
 	return query, vs, nil
 }
@@ -1126,7 +1126,7 @@ func (q userItemDeleteSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	query := "DELETE FROM user_item"
+	query := "DELETE FROM `user_item`"
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}

--- a/_example/user_sns.gen.go
+++ b/_example/user_sns.gen.go
@@ -258,7 +258,7 @@ func (q userSNSSelectSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	tableName := "user_sns"
+	tableName := "`user_sns`"
 	if q.tableAlias != "" {
 		tableName = tableName + " AS " + q.tableAlias
 		pcs := make([]string, 0, len(q.Columns))
@@ -509,7 +509,7 @@ func (q userSNSUpdateSQL) ToSql() (string, []interface{}, error) {
 		return "", []interface{}{}, err
 	}
 
-	query := "UPDATE user_sns SET" + setColumns
+	query := "UPDATE `user_sns` SET" + setColumns
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}
@@ -607,7 +607,7 @@ func (q userSNSInsertSQL) userSNSInsertSQLToSql() (string, []interface{}, error)
 		return "", []interface{}{}, err
 	}
 
-	query := "INSERT INTO user_sns " + qs
+	query := "INSERT INTO `user_sns` " + qs
 
 	return query, vs, nil
 }
@@ -945,7 +945,7 @@ func (q userSNSDeleteSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	query := "DELETE FROM user_sns"
+	query := "DELETE FROM `user_sns`"
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}

--- a/_example/user_sns_test.go
+++ b/_example/user_sns_test.go
@@ -10,7 +10,7 @@ func TestSelectUserSNS(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "SELECT `id`, `sns_type`, `created_at`, `updated_at` FROM user_sns WHERE `sns_type` = ?;" {
+	if query != "SELECT `id`, `sns_type`, `created_at`, `updated_at` FROM `user_sns` WHERE `sns_type` = ?;" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{"GITHUB"}) {

--- a/_example/user_test.go
+++ b/_example/user_test.go
@@ -25,7 +25,7 @@ func TestSelect(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "SELECT "+columns+" FROM user WHERE `name` = ?;" {
+	if query != "SELECT "+columns+" FROM `user` WHERE `name` = ?;" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{"hoge"}) {
@@ -39,7 +39,7 @@ func TestSelect__OrderByAndLimit(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "SELECT "+columns+" FROM user WHERE `name` = ? ORDER BY `id` ASC LIMIT 100;" {
+	if query != "SELECT "+columns+" FROM `user` WHERE `name` = ? ORDER BY `id` ASC LIMIT 100;" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{"hoge"}) {
@@ -53,7 +53,7 @@ func TestSelect__InOperator(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "SELECT "+columns+" FROM user WHERE `id` IN(?,?,?,?,?);" {
+	if query != "SELECT "+columns+" FROM `user` WHERE `id` IN(?,?,?,?,?);" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{uint64(1), uint64(2), uint64(3), uint64(4), uint64(5)}) {
@@ -67,7 +67,7 @@ func TestSelect__NullInt64(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "SELECT "+columns+" FROM user WHERE `age` IS NULL;" {
+	if query != "SELECT "+columns+" FROM `user` WHERE `age` IS NULL;" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{}) {
@@ -81,7 +81,7 @@ func TestSelect__NullInt64__IsNotNull(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "SELECT "+columns+" FROM user WHERE `age` IS NOT NULL;" {
+	if query != "SELECT "+columns+" FROM `user` WHERE `age` IS NOT NULL;" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{}) {
@@ -95,7 +95,7 @@ func TestSelect__ForUpdate(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "SELECT "+columns+" FROM user WHERE `id` = ? FOR UPDATE;" {
+	if query != "SELECT "+columns+" FROM `user` WHERE `id` = ? FOR UPDATE;" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{"1"}) {
@@ -112,7 +112,7 @@ func TestSelect__Or(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	expectedQuery := "SELECT " + columns + " FROM user WHERE (( `id` = ? ) OR ( `id` = ? ));"
+	expectedQuery := "SELECT " + columns + " FROM `user` WHERE (( `id` = ? ) OR ( `id` = ? ));"
 	if query != expectedQuery {
 		t.Error("unexpected query:", query, expectedQuery)
 	}
@@ -134,7 +134,7 @@ func TestSelect__OrNull(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	expectedQuery := "SELECT `id`, `user_id`, `item_id`, `is_used`, `has_extension`, `used_at` FROM user_item WHERE `id` IN(?,?) AND (( `used_at` IS NULL ) OR ( `used_at` < ? ));"
+	expectedQuery := "SELECT `id`, `user_id`, `item_id`, `is_used`, `has_extension`, `used_at` FROM `user_item` WHERE `id` IN(?,?) AND (( `used_at` IS NULL ) OR ( `used_at` < ? ));"
 	if query != expectedQuery {
 		t.Error("unexpected query:", query, expectedQuery)
 	}
@@ -155,7 +155,7 @@ func TestSelect__JoinClausesAndTableAlias(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	expectedQuery := "SELECT `u`.`id`, `u`.`name`, `u`.`age`, `u`.`rate`, `u`.`icon_image`, `u`.`created_at`, `u`.`updated_at`, ui.item_id, ui.is_used FROM user AS `u` INNER JOIN user_item AS ui ON u.id = ui.user_id WHERE `u`.`name` = ? AND ui.item_id IN (?,?,?) ORDER BY `u`.`id` DESC;"
+	expectedQuery := "SELECT `u`.`id`, `u`.`name`, `u`.`age`, `u`.`rate`, `u`.`icon_image`, `u`.`created_at`, `u`.`updated_at`, ui.item_id, ui.is_used FROM `user` AS `u` INNER JOIN user_item AS ui ON u.id = ui.user_id WHERE `u`.`name` = ? AND ui.item_id IN (?,?,?) ORDER BY `u`.`id` DESC;"
 	if query != expectedQuery {
 		t.Error("unexpected query:", query, expectedQuery)
 	}
@@ -174,7 +174,7 @@ func TestSelect__SetColumn(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	expectedQuery := "SELECT `u`.`rate`, COUNT(u.id) FROM user AS `u` GROUP BY `u`.`rate` ORDER BY `u`.`rate` DESC;"
+	expectedQuery := "SELECT `u`.`rate`, COUNT(u.id) FROM `user` AS `u` GROUP BY `u`.`rate` ORDER BY `u`.`rate` DESC;"
 	if query != expectedQuery {
 		t.Error("unexpected query:", query, expectedQuery)
 	}
@@ -193,7 +193,7 @@ func TestSelect__GroupByDottedColumn(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	expectedQuery := "SELECT `u`.`rate`, COUNT(u.id) FROM user AS `u` GROUP BY u.rate ORDER BY `u`.`rate` DESC;"
+	expectedQuery := "SELECT `u`.`rate`, COUNT(u.id) FROM `user` AS `u` GROUP BY u.rate ORDER BY `u`.`rate` DESC;"
 	if query != expectedQuery {
 		t.Error("unexpected query:", query, expectedQuery)
 	}
@@ -209,7 +209,7 @@ func TestSelect__LikeOperator(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	expectedQuery := "SELECT " + columns + " FROM user WHERE `name` LIKE ?;"
+	expectedQuery := "SELECT " + columns + " FROM `user` WHERE `name` LIKE ?;"
 	if query != expectedQuery {
 		t.Error("unexpected query:", query, expectedQuery)
 	}
@@ -225,14 +225,14 @@ func TestUpdate(t *testing.T) {
 		t.Error("unexpected error:", err)
 	}
 	switch query {
-	case "UPDATE user SET `name` = ?, `updated_at` = ? WHERE `id` = ?;":
+	case "UPDATE `user` SET `name` = ?, `updated_at` = ? WHERE `id` = ?;":
 		if !reflect.DeepEqual(args[0], "barbar") {
 			t.Error("unexpected args:", args)
 		}
 		if !reflect.DeepEqual(args[2], "1") {
 			t.Error("unexpected args:", args)
 		}
-	case "UPDATE user SET `updated_at` = ?, `name` = ? WHERE `id` = ?;":
+	case "UPDATE `user` SET `updated_at` = ?, `name` = ? WHERE `id` = ?;":
 		if !reflect.DeepEqual(args[2], "1") {
 			t.Error("unexpected args:", args)
 		}
@@ -251,7 +251,7 @@ func TestUpdate__InOperator(t *testing.T) {
 		t.Error("unexpected error:", err)
 	}
 	switch query {
-	case "UPDATE user SET `rate` = ?, `updated_at` = ? WHERE `id` IN(?,?,?);":
+	case "UPDATE `user` SET `rate` = ?, `updated_at` = ? WHERE `id` IN(?,?,?);":
 		if !reflect.DeepEqual(args[0], float64(42)) {
 			t.Errorf("unexpected args: %+v", args[0])
 		}
@@ -260,7 +260,7 @@ func TestUpdate__InOperator(t *testing.T) {
 				t.Errorf("unexpected args: i=%d, %+v", i, args[2:])
 			}
 		}
-	case "UPDATE user SET `updated_at` = ?, `rate` = ? WHERE `id` IN(?,?,?);":
+	case "UPDATE `user` SET `updated_at` = ?, `rate` = ? WHERE `id` IN(?,?,?);":
 		if !reflect.DeepEqual(args[1], float64(42)) {
 			t.Errorf("unexpected args: %+v", args[1])
 		}
@@ -281,7 +281,7 @@ func TestInsert(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	expected := "INSERT INTO user (`created_at`,`name`) VALUES(?,?);"
+	expected := "INSERT INTO `user` (`created_at`,`name`) VALUES(?,?);"
 	if query != expected {
 		t.Error("unexpected query:", query)
 	}
@@ -308,7 +308,7 @@ func TestInsertOnDuplicateKeyUpdate(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	expr := regexp.MustCompile(`^INSERT INTO user \(.*\) VALUES\(\?,\?,\?,\?\) `)
+	expr := regexp.MustCompile("^INSERT INTO `user` \\(.*\\) VALUES\\(\\?,\\?,\\?,\\?\\) ")
 	gotSuffix := expr.ReplaceAllString(query, "")
 	expectedSuffix1 := "ON DUPLICATE KEY UPDATE `age` = ?, `updated_at` = VALUES(`updated_at`);"
 	expectedSuffix2 := "ON DUPLICATE KEY UPDATE `updated_at` = VALUES(`updated_at`), `age` = ?;"
@@ -378,7 +378,7 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "DELETE FROM user WHERE `name` = ?;" {
+	if query != "DELETE FROM `user` WHERE `name` = ?;" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{"hogehoge"}) {
@@ -392,7 +392,7 @@ func TestDelete__In(t *testing.T) {
 	if err != nil {
 		t.Error("unexpected error:", err)
 	}
-	if query != "DELETE FROM user WHERE `name` IN(?,?);" {
+	if query != "DELETE FROM `user` WHERE `name` IN(?,?);" {
 		t.Error("unexpected query:", query)
 	}
 	if !reflect.DeepEqual(args, []interface{}{"hogehoge", "fugafuga"}) {

--- a/template/delete.tmpl
+++ b/template/delete.tmpl
@@ -18,7 +18,7 @@ func (q {{ $camelName }}DeleteSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	query := "DELETE FROM {{ .TableName }}"
+	query := "DELETE FROM `{{ .TableName }}`"
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}

--- a/template/insert.tmpl
+++ b/template/insert.tmpl
@@ -37,7 +37,7 @@ func (q {{ $camelName }}InsertSQL) {{ $camelName }}InsertSQLToSql() (string, []i
 		return "", []interface{}{}, err
 	}
 
-	query := "INSERT INTO {{ .TableName }} " + qs
+	query := "INSERT INTO `{{ .TableName }}` " + qs
 
 	return query, vs, nil
 }

--- a/template/select.tmpl
+++ b/template/select.tmpl
@@ -117,7 +117,7 @@ func (q {{ $camelName }}SelectSQL) ToSql() (string, []interface{}, error) {
 		return "", nil, err
 	}
 
-	tableName := "{{ .TableName }}"
+	tableName := "`{{ .TableName }}`"
 	if q.tableAlias != "" {
 		tableName = tableName + " AS " + q.tableAlias
 		pcs := make([]string, 0, len(q.Columns))

--- a/template/update.tmpl
+++ b/template/update.tmpl
@@ -32,7 +32,7 @@ func (q {{ $camelName }}UpdateSQL) ToSql() (string, []interface{}, error) {
 		return "", []interface{}{}, err
 	}
 
-	query := "UPDATE {{ .TableName }} SET" + setColumns
+	query := "UPDATE `{{ .TableName }}` SET" + setColumns
 	if wheres != "" {
 		query += " WHERE" + wheres
 	}


### PR DESCRIPTION
Fixes to enclose table name in backquote in SELECT/INSERT/UPDATE/DELETE statements.

BULK INSERT was already supported.