### PR TITLE
add: *SelectSQL.IterContext is returns iter.Seq2[*, error].

### DIFF
--- a/template/select.tmpl
+++ b/template/select.tmpl
@@ -245,4 +245,47 @@ func (q {{ $camelName }}SelectSQL) Scan(s sqlla.Scanner) ({{ .StructName }}, err
 	)
 	return row, err
 }
+
+// IterContext returns iter.Seq2[{{ .StructName }}, error] and closer.
+//
+// The returned Iter.Seq2 assembles and executes a query in the first iteration.
+// Therefore, the first iteration may return an error in assembling or executing the query.
+// Subsequent iterations read rows. Again, the read may return an error.
+//
+// closer is a function that closes the row reader object. Execution of this function is idempotent.
+// Be sure to call it when you are done using iter.Seq2.
+func (q {{ $camelName }}SelectSQL) IterContext(ctx context.Context, db sqlla.DB) (func (func ({{ .StructName }}, error) bool), func() error) {
+	var rowClose func() error
+	closer := func() error {
+		if rowClose != nil {
+			err := rowClose()
+			rowClose = nil
+			return err
+		}
+		return nil
+	}
+
+	q.Columns = {{ $camelName }}AllColumns
+	query, args, err := q.ToSql()
+	return func (yield func({{ .StructName}}, error) bool) {
+		if err != nil {
+			var r {{ .StructName }}
+			yield(r, err)
+			return
+		}
+		rows, err := db.QueryContext(ctx, query, args...)
+		if err != nil {
+			var r {{ .StructName }}
+			yield(r, err)
+			return
+		}
+		rowClose = rows.Close
+		for rows.Next() {
+			r, err := q.Scan(rows)
+			if !yield(r, err) {
+				break
+			}
+		}
+	}, closer
+}
 {{ end }}


### PR DESCRIPTION
### Description

This PR adds a new `IterContext` method to the generated code.

#### Key Features:
- `IterContext` returns `iter.Seq2[{{ row struct }}, error]` and a closer.
- Allows processing rows one by one using the syntax: `for row, err := range rows`.
- When combined with `github.com/BooleanCat/go-functional/v2/it`'s `TryCollect`, it can retrieve results similar to `AllContext`.
- Enables the use of `for range` in scenarios where you want to filter query results or transform them into another type.