### PR TITLE
fix(pg-template): omit PkColumn(pk int64) method in *SelectSQL

### DIFF
--- a/_example/postgresql/accounts.gen.go
+++ b/_example/postgresql/accounts.gen.go
@@ -143,11 +143,6 @@ func (q accountSelectSQL) IDIn(vs ...AccountID) accountSelectSQL {
 	return q
 }
 
-func (q accountSelectSQL) PkColumn(pk int64, exprs ...sqlla.Operator) accountSelectSQL {
-	v := AccountID(pk)
-	return q.ID(v, exprs...)
-}
-
 func (q accountSelectSQL) OrderByID(order sqlla.Order) accountSelectSQL {
 	q.order = order.WithColumn(q.appendColumnPrefix("\"id\""))
 	return q

--- a/_example/postgresql/groups.gen.go
+++ b/_example/postgresql/groups.gen.go
@@ -141,11 +141,6 @@ func (q groupSelectSQL) IDIn(vs ...GroupID) groupSelectSQL {
 	return q
 }
 
-func (q groupSelectSQL) PkColumn(pk int64, exprs ...sqlla.Operator) groupSelectSQL {
-	v := GroupID(pk)
-	return q.ID(v, exprs...)
-}
-
 func (q groupSelectSQL) OrderByID(order sqlla.Order) groupSelectSQL {
 	q.order = order.WithColumn(q.appendColumnPrefix("\"id\""))
 	return q

--- a/_example/postgresql/identities.gen.go
+++ b/_example/postgresql/identities.gen.go
@@ -141,11 +141,6 @@ func (q identitySelectSQL) IDIn(vs ...IdentityID) identitySelectSQL {
 	return q
 }
 
-func (q identitySelectSQL) PkColumn(pk int64, exprs ...sqlla.Operator) identitySelectSQL {
-	v := IdentityID(pk)
-	return q.ID(v, exprs...)
-}
-
 func (q identitySelectSQL) OrderByID(order sqlla.Order) identitySelectSQL {
 	q.order = order.WithColumn(q.appendColumnPrefix("\"id\""))
 	return q

--- a/template/select_column.tmpl
+++ b/template/select_column.tmpl
@@ -24,7 +24,7 @@ func (q {{ $smallTableName }}SelectSQL) {{ .MethodName }}In(vs ...{{ .TypeName }
 }
 {{- end }}
 
-{{ if .IsPk -}}
+{{ if and .IsPk (eq (dialect) "mysql") -}}
 func (q {{ $smallTableName }}SelectSQL) PkColumn(pk int64, exprs ...sqlla.Operator) {{ $smallTableName }}SelectSQL {
 	v := {{ .TypeName }}(pk)
 	return q.{{ .MethodName }}(v, exprs...)


### PR DESCRIPTION
This pull request includes changes to the SQL query generation for PostgreSQL and MySQL within the `_example` directory. The main focus is on removing unnecessary methods and refining template conditions.

Refinement of SQL query generation:

* The `PkColumn` method was removed because PostgreSQL's implementation does not use `LastInsertId` to retrieve the inserted row unlike MySQL. Since `LastInsertId` returns an int64, the `PkColumn` method was needed for MySQL; however, PostgreSQL uses `RETURNING` and therefore does not require the `PkColumn` method.
* [`_example/postgresql/accounts.gen.go`](diffhunk://#diff-db6a2e153797c47f18c293140f12a429d3bbc8268073fb5fb4ab8fdf3c7ed4adL146-L150): Removed the `PkColumn` method from the `accountSelectSQL` struct.
* [`_example/postgresql/groups.gen.go`](diffhunk://#diff-8d29e5c792d2bc3a48fe917a1ab7f924b95bd7887872af9a771a61e4b5ed83a6L144-L148): Removed the `PkColumn` method from the `groupSelectSQL` struct.
* [`_example/postgresql/identities.gen.go`](diffhunk://#diff-9fe4bb96a365526f496a3d564e9dc4fb91d18e3e5e355793898c06eb2dfa4427L144-L148): Removed the `PkColumn` method from the `identitySelectSQL` struct.

Template condition improvements:

* [`template/select_column.tmpl`](diffhunk://#diff-9721c67ccbdf8c582094e224b3efed57d57bef047c4726dc6577da607be020e1L27-R27): Updated the condition to generate the `PkColumn` method only for MySQL by adding a check for the dialect.