### PR TITLE
fix(template): avoid variable shadowing in generated TableType methods by prefixing underscore

### DIFF
--- a/_example/postgresql/identities.plugin.gen.go
+++ b/_example/postgresql/identities.plugin.gen.go
@@ -3,15 +3,15 @@ package postgresql
 
 import "time"
 
-func (i Identity) DefaultInsertHook(q identityInsertSQL) (identityInsertSQL, error) {
+func (i Identity) DefaultInsertHook(_q identityInsertSQL) (identityInsertSQL, error) {
 	now := time.Now()
-	return q.
+	return _q.
 		ValueCreatedAt(now).
 		ValueUpdatedAt(now), nil
 }
 
-func (i Identity) DefaultUpdateHook(q identityUpdateSQL) (identityUpdateSQL, error) {
+func (i Identity) DefaultUpdateHook(_q identityUpdateSQL) (identityUpdateSQL, error) {
 	now := time.Now()
-	return q.
+	return _q.
 		SetUpdatedAt(now), nil
 }

--- a/_example/user.plugin.gen.go
+++ b/_example/user.plugin.gen.go
@@ -21,14 +21,14 @@ func (q userSelectSQL) CountContext(ctx context.Context, db sqlla.DB, column str
 	return count, nil
 }
 
-func (u User) DefaultInsertHook(q userInsertSQL) (userInsertSQL, error) {
+func (u User) DefaultInsertHook(_q userInsertSQL) (userInsertSQL, error) {
 	now := time.Now()
-	return q.
+	return _q.
 		ValueCreatedAt(now), nil
 }
 
-func (u User) DefaultInsertOnDuplicateKeyUpdateHook(q userInsertOnDuplicateKeyUpdateSQL) (userInsertOnDuplicateKeyUpdateSQL, error) {
-	return q.
+func (u User) DefaultInsertOnDuplicateKeyUpdateHook(_q userInsertOnDuplicateKeyUpdateSQL) (userInsertOnDuplicateKeyUpdateSQL, error) {
+	return _q.
 		SameOnUpdateUpdatedAt(), nil
 }
 
@@ -36,32 +36,32 @@ type Users []*User
 
 func (u Users) Ids() []UserId {
 	vs := make([]UserId, len(u))
-	for i := range u {
-		vs[i] = u[i].Id
+	for _i := range u {
+		vs[_i] = u[_i].Id
 	}
 	return vs
 }
 
 func (u Users) Names() []string {
 	vs := make([]string, len(u))
-	for i := range u {
-		vs[i] = u[i].Name
+	for _i := range u {
+		vs[_i] = u[_i].Name
 	}
 	return vs
 }
 
 func (u Users) AssociateByIds() map[UserId]*User {
-	m := make(map[UserId]*User, len(u))
-	for _, v := range u {
-		m[v.Id] = v
+	_m := make(map[UserId]*User, len(u))
+	for _, _v := range u {
+		_m[_v.Id] = _v
 	}
-	return m
+	return _m
 }
 
 func (u Users) GroupByNames() map[string]Users {
-	m := make(map[string]Users, len(u))
-	for _, v := range u {
-		m[v.Name] = append(m[v.Name], v)
+	_m := make(map[string]Users, len(u))
+	for _, _v := range u {
+		_m[_v.Name] = append(_m[_v.Name], _v)
 	}
-	return m
+	return _m
 }

--- a/template/plugins/slice.tmpl
+++ b/template/plugins/slice.tmpl
@@ -11,8 +11,8 @@ type {{ $sliceTypeName }} []*{{ $structName }}
 {{- $methodName := pluralize $column.FieldName }}
 func ({{ $receiver }} {{ $sliceTypeName }}) {{ $methodName }}() []{{ $column.TypeName }} {
 	vs := make([]{{ $column.TypeName }}, len({{ $receiver }}))
-	for i := range {{ $receiver }} {
-		vs[i] = {{ $receiver }}[i].{{ $column.FieldName }}
+	for _i := range {{ $receiver }} {
+		vs[_i] = {{ $receiver }}[_i].{{ $column.FieldName }}
 	}
 	return vs
 }
@@ -25,11 +25,11 @@ func ({{ $receiver }} {{ $sliceTypeName }}) {{ $methodName }}() []{{ $column.Typ
 {{- $column := $table.Lookup $columnName }}
 {{- $fieldName := pluralize $column.FieldName }}
 func ( {{ $receiver }} {{ $sliceTypeName }}) AssociateBy{{ $fieldName }}() map[{{ $column.TypeName }}]*{{ $structName }} {
-	m := make(map[{{ $column.TypeName }}]*{{ $structName }}, len({{ $receiver }}))
-	for _, v := range {{ $receiver }} {
-		m[v.{{ $column.FieldName }}] = v
+	_m := make(map[{{ $column.TypeName }}]*{{ $structName }}, len({{ $receiver }}))
+	for _, _v := range {{ $receiver }} {
+		_m[_v.{{ $column.FieldName }}] = _v
 	}
-	return m
+	return _m
 }
 {{ end }}
 {{- end }}
@@ -40,11 +40,11 @@ func ( {{ $receiver }} {{ $sliceTypeName }}) AssociateBy{{ $fieldName }}() map[{
 {{- $column := $table.Lookup $columnName }}
 {{- $fieldName := pluralize $column.FieldName }}
 func ( {{ $receiver }} {{ $sliceTypeName }}) GroupBy{{ $fieldName }}() map[{{ $column.TypeName }}]{{ $sliceTypeName }} {
-	m := make(map[{{ $column.TypeName }}]{{ $sliceTypeName }}, len({{ $receiver }}))
-	for _, v := range {{ $receiver }} {
-		m[v.{{ $column.FieldName }}] = append(m[v.{{ $column.FieldName }}], v)
+	_m := make(map[{{ $column.TypeName }}]{{ $sliceTypeName }}, len({{ $receiver }}))
+	for _, _v := range {{ $receiver }} {
+		_m[_v.{{ $column.FieldName }}] = append(_m[_v.{{ $column.FieldName }}], _v)
 	}
-	return m
+	return _m
 }
 {{ end }}
 {{- end }}

--- a/template/plugins/timeHooks.tmpl
+++ b/template/plugins/timeHooks.tmpl
@@ -4,9 +4,9 @@
 {{ if not (empty .Args.create) }}
 {{- $createHookColumns := splitList "," .Args.create }}
 {{- $insertSQLTypeName := printf "%sInsertSQL" ($structName | untitle) }}
-func ({{$receiver}} {{$structName}}) DefaultInsertHook(q {{ $insertSQLTypeName }}) ({{ $insertSQLTypeName }}, error) {
+func ({{$receiver}} {{$structName}}) DefaultInsertHook(_q {{ $insertSQLTypeName }}) ({{ $insertSQLTypeName }}, error) {
 	now := time.Now()
-	return q.
+	return _q.
 	{{- $lastIndex := sub (len $createHookColumns) 1 }}
 	{{- range $index, $column := $createHookColumns }}
 		Value{{ $column }}(now){{ if ne $lastIndex $index }}.{{ end }}
@@ -17,9 +17,9 @@ func ({{$receiver}} {{$structName}}) DefaultInsertHook(q {{ $insertSQLTypeName }
 {{ if not (empty .Args.update) }}
 {{- $updateHookColumns := splitList "," .Args.update }}
 {{- $updateSQLTypeName := printf "%sUpdateSQL" ($structName | untitle) }}
-func ({{$receiver}} {{$structName}}) DefaultUpdateHook(q {{ $updateSQLTypeName }}) ({{ $updateSQLTypeName }}, error) {
+func ({{$receiver}} {{$structName}}) DefaultUpdateHook(_q {{ $updateSQLTypeName }}) ({{ $updateSQLTypeName }}, error) {
 	now := time.Now()
-	return q.
+	return _q.
 	{{- $lastIndex := sub (len $updateHookColumns) 1 }}
 	{{- range $index, $column := $updateHookColumns }}
 		Set{{ $column }}(now){{ if ne $lastIndex $index }}.{{ end }}
@@ -30,8 +30,8 @@ func ({{$receiver}} {{$structName}}) DefaultUpdateHook(q {{ $updateSQLTypeName }
 {{ if not (empty .Args.sameOnUpdate) }}
 {{- $sameOnUpdateColumns := splitList "," .Args.sameOnUpdate }}
 {{- $insertOnDuplicateKeyUpdateSQLTypeName := printf "%sInsertOnDuplicateKeyUpdateSQL" (.Table.StructName | untitle) }}
-func ({{$receiver}} {{$structName}}) DefaultInsertOnDuplicateKeyUpdateHook(q {{ $insertOnDuplicateKeyUpdateSQLTypeName }}) ({{ $insertOnDuplicateKeyUpdateSQLTypeName }}, error) {
-	return q.
+func ({{$receiver}} {{$structName}}) DefaultInsertOnDuplicateKeyUpdateHook(_q {{ $insertOnDuplicateKeyUpdateSQLTypeName }}) ({{ $insertOnDuplicateKeyUpdateSQLTypeName }}, error) {
+	return _q.
 	{{- $lastIndex := sub (len $sameOnUpdateColumns) 1 }}
 	{{- range $index, $column := $sameOnUpdateColumns }}
 		SameOnUpdate{{ $column }}(){{ if ne $lastIndex $index }}.{{ end }}


### PR DESCRIPTION
Prefixed an underscore to local variables in template-generated TableType methods to prevent shadowing of receiver or method arguments. This update maintains code clarity and resolves potential variable name conflicts in methods such as plural getters, AssociateBy, GroupBy, and time hook hooks.