### PR TITLE
feat(plugin/table): generate helper methods for single-column 'get' with IN queries

### DIFF
--- a/_example/go.mod
+++ b/_example/go.mod
@@ -1,7 +1,6 @@
 module github.com/mackee/go-sqlla/_example
 
-go 1.22.0
-toolchain go1.24.1
+go 1.24.2
 
 replace github.com/mackee/go-sqlla/v2 => ../
 

--- a/_example/group.go
+++ b/_example/group.go
@@ -13,7 +13,7 @@ type GroupID uint64
 //genddl:table group
 //sqlla:plugin myrelations key=LeaderUserID:User.ID method=Leader
 //sqlla:plugin slice
-//sqlla:plugin table get=ID&LeaderUserID list=LeaderUserID&SubLeaderUserID create=Name,LeaderUserID,SubLeaderUserID,ChildGroupID,CreatedAt
+//sqlla:plugin table get=ID&LeaderUserID,ID list=LeaderUserID&SubLeaderUserID create=Name,LeaderUserID,SubLeaderUserID,ChildGroupID,CreatedAt
 type Group struct {
 	ID              GroupID         `db:"id,primarykey,autoincrement"`
 	Name            string          `db:"name"`

--- a/_example/group.plugin.gen.go
+++ b/_example/group.plugin.gen.go
@@ -37,6 +37,30 @@ func (g *GroupTable) GetByIDAndLeaderUserID(ctx context.Context, db sqlla.DB, c0
 	return &row, nil
 }
 
+func (g *GroupTable) GetByID(ctx context.Context, db sqlla.DB, c0 GroupID) (*Group, error) {
+	row, err := NewGroupSQL().Select().
+		ID(c0).
+		SingleContext(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Group by ID: %w", err)
+	}
+	return &row, nil
+}
+
+func (g *GroupTable) ListByIDS(ctx context.Context, db sqlla.DB, cs []GroupID) (Groups, error) {
+	_rows, err := NewGroupSQL().Select().
+		IDIn(cs...).
+		AllContext(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Groups by IDS: %w", err)
+	}
+	rows := make(Groups, len(_rows))
+	for i := range _rows {
+		rows[i] = &_rows[i]
+	}
+	return rows, nil
+}
+
 func (g *GroupTable) ListByLeaderUserIDAndSubLeaderUserID(ctx context.Context, db sqlla.DB, c0 UserId, c1 int64) (Groups, error) {
 	_rows, err := NewGroupSQL().Select().
 		LeaderUserID(c0).

--- a/_example/group_plugin_test.go
+++ b/_example/group_plugin_test.go
@@ -49,4 +49,26 @@ func TestPlugin__Group__Table(t *testing.T) {
 	if len(rows) != 2 {
 		t.Error("unexpected len(rows):", len(rows))
 	}
+
+	allRows, closer := example.NewGroupSQL().Select().IterContext(ctx, db)
+	var ids []example.GroupID
+	func() {
+		defer closer()
+		for row, err := range allRows {
+			if err != nil {
+				t.Error("cannot iterate rows error:", err)
+			}
+			if row.ID == 0 {
+				t.Error("unexpected row.ID:", row.ID)
+			}
+			ids = append(ids, row.ID)
+		}
+	}()
+	expectedRows, err := table.ListByIDS(ctx, db, ids)
+	if err != nil {
+		t.Error("cannot list rows by ids error:", err)
+	}
+	if len(expectedRows) != len(ids) {
+		t.Error("unexpected len(expectedRows):", len(expectedRows))
+	}
 }

--- a/template/plugins/table.tmpl
+++ b/template/plugins/table.tmpl
@@ -32,6 +32,24 @@ func ({{ $receiver }} *{{ $tableTypeName }}) GetBy{{ $methodName }}(ctx context.
 	}
 	return &row, nil
 }
+{{- if eq (len $columnNames) 1 }}
+{{ $columnName := index $columnNames 0 }}
+{{ $listColumnName := $columnName | pluralize }}
+func ({{ $receiver }} *{{ $tableTypeName }}) ListBy{{ $listColumnName }}(ctx context.Context, db sqlla.DB, cs []{{ ($table.Lookup $columnName).TypeName }}) ({{ $sliceTypeName }}, error) {
+	_rows, err := New{{ $structName }}SQL().Select().
+		{{ $column := $table.Lookup $columnName }}
+		{{ $column.MethodName }}In(cs...).
+		AllContext(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list {{ $structName | pluralize }} by {{ $listColumnName }}: %w", err)
+	}
+	rows := make({{ $sliceTypeName }}, len(_rows))
+	for i := range _rows {
+		rows[i] = &_rows[i]
+	}
+	return rows, nil
+}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
When the 'get' property in the Table plugin is specified with a single column, a helper method is now generated to retrieve rows using an IN(...) query on that column. This simplifies batch retrievals by primary key or other unique columns, and includes tests and template adjustments for automatic method generation.