### PR TITLE
Feature/generate return row by returning in postgresql

### DIFF
--- a/_example/group.gen.go
+++ b/_example/group.gen.go
@@ -787,6 +787,10 @@ func (q groupInsertSQL) ToSql() (string, []any, error) {
 	return query + ";", vs, nil
 }
 
+func (q groupInsertSQL) rowsNum() int {
+	return 1
+}
+
 func (q groupInsertSQL) groupInsertSQLToSql() (string, []any, error) {
 	var err error
 	var s interface{} = Group{}
@@ -806,19 +810,7 @@ func (q groupInsertSQL) groupInsertSQLToSql() (string, []any, error) {
 }
 
 func (q groupInsertSQL) Exec(db sqlla.DB) (Group, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return Group{}, err
-	}
-	result, err := db.Exec(query, args...)
-	if err != nil {
-		return Group{}, err
-	}
-	id, err := result.LastInsertId()
-	if err != nil {
-		return Group{}, err
-	}
-	return NewGroupSQL().Select().PkColumn(id).Single(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q groupInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) (Group, error) {
@@ -851,6 +843,7 @@ type groupDefaultInsertHooker interface {
 }
 
 type groupInsertSQLToSqler interface {
+	rowsNum() int
 	groupInsertSQLToSql() (string, []any, error)
 }
 
@@ -866,6 +859,10 @@ func (q groupSQL) BulkInsert() *groupBulkInsertSQL {
 
 func (q *groupBulkInsertSQL) Append(iqs ...groupInsertSQL) {
 	q.insertSQLs = append(q.insertSQLs, iqs...)
+}
+
+func (q *groupBulkInsertSQL) rowsNum() int {
+	return len(q.insertSQLs)
 }
 
 func (q *groupBulkInsertSQL) groupInsertSQLToSql() (string, []any, error) {

--- a/_example/group.gen.go
+++ b/_example/group.gen.go
@@ -690,17 +690,7 @@ func (s Group) Update() groupUpdateSQL {
 }
 
 func (q groupUpdateSQL) Exec(db sqlla.DB) ([]Group, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return nil, err
-	}
-	_, err = db.Exec(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	qq := q.groupSQL
-
-	return qq.Select().All(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q groupUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Group, error) {

--- a/_example/postgresql/account_test.go
+++ b/_example/postgresql/account_test.go
@@ -417,7 +417,7 @@ func testCases() []testCaseWithToQueryTestCase {
 			query: postgresql.NewAccountSQL().Insert().
 				ValueName("foo").
 				ValueEmbedding(sampleVector),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4);`,
 			vs:       []any{sampleDate, sampleVector, "foo", sampleDate},
 			expectedResult: postgresql.Account{
 				ID:        1,
@@ -436,7 +436,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				ValueChildGroupIDIsNull().
 				ValueCreatedAt(sampleDate).
 				ValueUpdatedAt(sampleDate),
-			expected: `INSERT INTO "groups" ("child_group_id","created_at","leader_account_id","name","sub_leader_account_id","updated_at") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id", "name", "leader_account_id", "sub_leader_account_id", "child_group_id", "created_at", "updated_at";`,
+			expected: `INSERT INTO "groups" ("child_group_id","created_at","leader_account_id","name","sub_leader_account_id","updated_at") VALUES ($1,$2,$3,$4,$5,$6);`,
 			vs:       []any{sql.Null[int64]{}, sampleDate, int64(42), "foo", int64(28), sampleDate},
 			expectedResult: postgresql.Group{
 				ID:                 1,
@@ -454,7 +454,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				ValueName("foo").
 				ValueEmbedding(sampleVector).
 				OnConflictDoNothing(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING;`,
 			vs:       []any{sampleDate, sampleVector, "foo", sampleDate},
 			expectedResult: postgresql.Account{
 				ID:        1,
@@ -472,7 +472,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				OnConflictDoUpdate("id").
 				ValueOnUpdateName("powawa").
 				SameOnUpdateEmbedding(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) ON CONFLICT (id) DO UPDATE SET "embedding" = "excluded"."embedding", "name" = $5 RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) ON CONFLICT (id) DO UPDATE SET "embedding" = "excluded"."embedding", "name" = $5;`,
 			vs:       []any{sampleDate, sampleVector, "foo", sampleDate, "powawa"},
 			expectedResult: postgresql.Account{
 				ID:        1,
@@ -494,7 +494,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				}
 				return bi
 			}(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4),($5,$6,$7,$8),($9,$10,$11,$12) RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4),($5,$6,$7,$8),($9,$10,$11,$12);`,
 			vs: []any{
 				sampleDate,
 				sampleVector,
@@ -527,7 +527,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				}
 				return bi.OnConflictDoNothing()
 			}(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4),($5,$6,$7,$8),($9,$10,$11,$12) ON CONFLICT DO NOTHING RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4),($5,$6,$7,$8),($9,$10,$11,$12) ON CONFLICT DO NOTHING;`,
 			vs: []any{
 				sampleDate,
 				sampleVector,
@@ -563,7 +563,7 @@ func testCases() []testCaseWithToQueryTestCase {
 					ValueOnUpdateName("powawa").
 					SameOnUpdateEmbedding()
 			}(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","id","name","updated_at") VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10),($11,$12,$13,$14,$15) ON CONFLICT (id) DO UPDATE SET "embedding" = "excluded"."embedding", "name" = $16 RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","id","name","updated_at") VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10),($11,$12,$13,$14,$15) ON CONFLICT (id) DO UPDATE SET "embedding" = "excluded"."embedding", "name" = $16;`,
 			vs: []any{
 				sampleDate,
 				sampleVector,

--- a/_example/postgresql/account_test.go
+++ b/_example/postgresql/account_test.go
@@ -413,7 +413,7 @@ func testCases() []testCaseWithToQueryTestCase {
 			query: postgresql.NewAccountSQL().Insert().
 				ValueName("foo").
 				ValueEmbedding(sampleVector),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) RETURNING "id";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
 			vs:       []any{sampleDate, sampleVector, "foo", sampleDate},
 			expectedResult: postgresql.Account{
 				ID:        1,
@@ -432,7 +432,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				ValueChildGroupIDIsNull().
 				ValueCreatedAt(sampleDate).
 				ValueUpdatedAt(sampleDate),
-			expected: `INSERT INTO "groups" ("child_group_id","created_at","leader_account_id","name","sub_leader_account_id","updated_at") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id";`,
+			expected: `INSERT INTO "groups" ("child_group_id","created_at","leader_account_id","name","sub_leader_account_id","updated_at") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id", "name", "leader_account_id", "sub_leader_account_id", "child_group_id", "created_at", "updated_at";`,
 			vs:       []any{sql.Null[int64]{}, sampleDate, int64(42), "foo", int64(28), sampleDate},
 			expectedResult: postgresql.Group{
 				ID:                 1,
@@ -450,7 +450,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				ValueName("foo").
 				ValueEmbedding(sampleVector).
 				OnConflictDoNothing(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING RETURNING "id";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
 			vs:       []any{sampleDate, sampleVector, "foo", sampleDate},
 			expectedResult: postgresql.Account{
 				ID:        1,
@@ -468,7 +468,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				OnConflictDoUpdate("id").
 				ValueOnUpdateName("powawa").
 				SameOnUpdateEmbedding(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) ON CONFLICT (id) DO UPDATE SET "embedding" = "excluded"."embedding", "name" = $5 RETURNING "id";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4) ON CONFLICT (id) DO UPDATE SET "embedding" = "excluded"."embedding", "name" = $5 RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
 			vs:       []any{sampleDate, sampleVector, "foo", sampleDate, "powawa"},
 			expectedResult: postgresql.Account{
 				ID:        1,
@@ -490,7 +490,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				}
 				return bi
 			}(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4),($5,$6,$7,$8),($9,$10,$11,$12) RETURNING "id";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4),($5,$6,$7,$8),($9,$10,$11,$12) RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
 			vs: []any{
 				sampleDate,
 				sampleVector,
@@ -523,7 +523,7 @@ func testCases() []testCaseWithToQueryTestCase {
 				}
 				return bi.OnConflictDoNothing()
 			}(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4),($5,$6,$7,$8),($9,$10,$11,$12) ON CONFLICT DO NOTHING RETURNING "id";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","name","updated_at") VALUES ($1,$2,$3,$4),($5,$6,$7,$8),($9,$10,$11,$12) ON CONFLICT DO NOTHING RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
 			vs: []any{
 				sampleDate,
 				sampleVector,
@@ -559,7 +559,7 @@ func testCases() []testCaseWithToQueryTestCase {
 					ValueOnUpdateName("powawa").
 					SameOnUpdateEmbedding()
 			}(),
-			expected: `INSERT INTO "accounts" ("created_at","embedding","id","name","updated_at") VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10),($11,$12,$13,$14,$15) ON CONFLICT (id) DO UPDATE SET "embedding" = "excluded"."embedding", "name" = $16 RETURNING "id";`,
+			expected: `INSERT INTO "accounts" ("created_at","embedding","id","name","updated_at") VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10),($11,$12,$13,$14,$15) ON CONFLICT (id) DO UPDATE SET "embedding" = "excluded"."embedding", "name" = $16 RETURNING "id", "name", "embedding", "created_at", "updated_at";`,
 			vs: []any{
 				sampleDate,
 				sampleVector,

--- a/_example/postgresql/accounts.gen.go
+++ b/_example/postgresql/accounts.gen.go
@@ -616,8 +616,17 @@ func (q accountInsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", []any{}, err
 	}
-	columns := strings.Join(accountAllColumns, ", ")
-	return query + " RETURNING " + columns + ";", vs, nil
+	return query + ";", vs, nil
+}
+
+func (q accountInsertSQL) ToSqlWithReturning() (string, []any, error) {
+	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []any{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(accountAllColumns, ", ")
+	return query, args, nil
 }
 
 func (q accountInsertSQL) rowsNum() int {
@@ -647,7 +656,7 @@ func (q accountInsertSQL) Exec(db sqlla.DB) (Account, error) {
 }
 
 func (q accountInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) (Account, error) {
-	query, args, err := q.ToSql()
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Account{}, err
 	}
@@ -731,11 +740,20 @@ func (q *accountBulkInsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", []any{}, err
 	}
-	columns := strings.Join(accountAllColumns, ", ")
-	return query + " RETURNING " + columns + ";", vs, nil
+	return query + ";", vs, nil
 }
-func (q *accountBulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Account, error) {
+func (q *accountBulkInsertSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []any{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(accountAllColumns, ", ")
+	return query + ";", args, nil
+}
+
+func (q *accountBulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Account, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}
@@ -780,14 +798,24 @@ func (q accountInsertOnConflictDoNothingSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	columns := strings.Join(accountAllColumns, ", ")
-	query += " ON CONFLICT DO NOTHING" + " RETURNING " + columns
+	query += " ON CONFLICT DO NOTHING"
 	return query + ";", vs, nil
 
 }
 
-func (q accountInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) (Account, error) {
+func (q accountInsertOnConflictDoNothingSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(accountAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q accountInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) (Account, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Account{}, err
 	}
@@ -921,14 +949,23 @@ func (q accountInsertOnConflictDoUpdateSQL) ToSql() (string, []any, error) {
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join(accountAllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 }
 
-func (q accountInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (Account, error) {
+func (q accountInsertOnConflictDoUpdateSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(accountAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q accountInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (Account, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Account{}, err
 	}
@@ -971,14 +1008,24 @@ func (q accountBulkInsertOnConflictDoNothingSQL) ToSql() (string, []any, error) 
 	if err != nil {
 		return "", nil, err
 	}
-	columns := strings.Join(accountAllColumns, ", ")
-	query += " ON CONFLICT DO NOTHING" + " RETURNING " + columns
+	query += " ON CONFLICT DO NOTHING"
 	return query + ";", vs, nil
 
 }
 
-func (q accountBulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Account, error) {
+func (q accountBulkInsertOnConflictDoNothingSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(accountAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q accountBulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Account, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}
@@ -1129,14 +1176,23 @@ func (q accountBulkInsertOnConflictDoUpdateSQL) ToSql() (string, []any, error) {
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join(accountAllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 }
 
-func (q accountBulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Account, error) {
+func (q accountBulkInsertOnConflictDoUpdateSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(accountAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q accountBulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Account, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}

--- a/_example/postgresql/groups.gen.go
+++ b/_example/postgresql/groups.gen.go
@@ -786,8 +786,17 @@ func (q groupInsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", []any{}, err
 	}
-	columns := strings.Join(groupAllColumns, ", ")
-	return query + " RETURNING " + columns + ";", vs, nil
+	return query + ";", vs, nil
+}
+
+func (q groupInsertSQL) ToSqlWithReturning() (string, []any, error) {
+	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []any{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(groupAllColumns, ", ")
+	return query, args, nil
 }
 
 func (q groupInsertSQL) rowsNum() int {
@@ -817,7 +826,7 @@ func (q groupInsertSQL) Exec(db sqlla.DB) (Group, error) {
 }
 
 func (q groupInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) (Group, error) {
-	query, args, err := q.ToSql()
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Group{}, err
 	}
@@ -901,11 +910,20 @@ func (q *groupBulkInsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", []any{}, err
 	}
-	columns := strings.Join(groupAllColumns, ", ")
-	return query + " RETURNING " + columns + ";", vs, nil
+	return query + ";", vs, nil
 }
-func (q *groupBulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Group, error) {
+func (q *groupBulkInsertSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []any{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(groupAllColumns, ", ")
+	return query + ";", args, nil
+}
+
+func (q *groupBulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Group, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}
@@ -950,14 +968,24 @@ func (q groupInsertOnConflictDoNothingSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	columns := strings.Join(groupAllColumns, ", ")
-	query += " ON CONFLICT DO NOTHING" + " RETURNING " + columns
+	query += " ON CONFLICT DO NOTHING"
 	return query + ";", vs, nil
 
 }
 
-func (q groupInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) (Group, error) {
+func (q groupInsertOnConflictDoNothingSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(groupAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q groupInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) (Group, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Group{}, err
 	}
@@ -1131,14 +1159,23 @@ func (q groupInsertOnConflictDoUpdateSQL) ToSql() (string, []any, error) {
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join(groupAllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 }
 
-func (q groupInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (Group, error) {
+func (q groupInsertOnConflictDoUpdateSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(groupAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q groupInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (Group, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Group{}, err
 	}
@@ -1181,14 +1218,24 @@ func (q groupBulkInsertOnConflictDoNothingSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	columns := strings.Join(groupAllColumns, ", ")
-	query += " ON CONFLICT DO NOTHING" + " RETURNING " + columns
+	query += " ON CONFLICT DO NOTHING"
 	return query + ";", vs, nil
 
 }
 
-func (q groupBulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Group, error) {
+func (q groupBulkInsertOnConflictDoNothingSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(groupAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q groupBulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Group, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}
@@ -1379,14 +1426,23 @@ func (q groupBulkInsertOnConflictDoUpdateSQL) ToSql() (string, []any, error) {
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join(groupAllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 }
 
-func (q groupBulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Group, error) {
+func (q groupBulkInsertOnConflictDoUpdateSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(groupAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q groupBulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Group, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}

--- a/_example/postgresql/identities.gen.go
+++ b/_example/postgresql/identities.gen.go
@@ -622,8 +622,17 @@ func (q identityInsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", []any{}, err
 	}
-	columns := strings.Join(identityAllColumns, ", ")
-	return query + " RETURNING " + columns + ";", vs, nil
+	return query + ";", vs, nil
+}
+
+func (q identityInsertSQL) ToSqlWithReturning() (string, []any, error) {
+	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []any{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(identityAllColumns, ", ")
+	return query, args, nil
 }
 
 func (q identityInsertSQL) rowsNum() int {
@@ -653,7 +662,7 @@ func (q identityInsertSQL) Exec(db sqlla.DB) (Identity, error) {
 }
 
 func (q identityInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) (Identity, error) {
-	query, args, err := q.ToSql()
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Identity{}, err
 	}
@@ -737,11 +746,20 @@ func (q *identityBulkInsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", []any{}, err
 	}
-	columns := strings.Join(identityAllColumns, ", ")
-	return query + " RETURNING " + columns + ";", vs, nil
+	return query + ";", vs, nil
 }
-func (q *identityBulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Identity, error) {
+func (q *identityBulkInsertSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []any{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(identityAllColumns, ", ")
+	return query + ";", args, nil
+}
+
+func (q *identityBulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Identity, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}
@@ -786,14 +804,24 @@ func (q identityInsertOnConflictDoNothingSQL) ToSql() (string, []any, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	columns := strings.Join(identityAllColumns, ", ")
-	query += " ON CONFLICT DO NOTHING" + " RETURNING " + columns
+	query += " ON CONFLICT DO NOTHING"
 	return query + ";", vs, nil
 
 }
 
-func (q identityInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) (Identity, error) {
+func (q identityInsertOnConflictDoNothingSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(identityAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q identityInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) (Identity, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Identity{}, err
 	}
@@ -927,14 +955,23 @@ func (q identityInsertOnConflictDoUpdateSQL) ToSql() (string, []any, error) {
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join(identityAllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 }
 
-func (q identityInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (Identity, error) {
+func (q identityInsertOnConflictDoUpdateSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(identityAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q identityInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (Identity, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return Identity{}, err
 	}
@@ -977,14 +1014,24 @@ func (q identityBulkInsertOnConflictDoNothingSQL) ToSql() (string, []any, error)
 	if err != nil {
 		return "", nil, err
 	}
-	columns := strings.Join(identityAllColumns, ", ")
-	query += " ON CONFLICT DO NOTHING" + " RETURNING " + columns
+	query += " ON CONFLICT DO NOTHING"
 	return query + ";", vs, nil
 
 }
 
-func (q identityBulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Identity, error) {
+func (q identityBulkInsertOnConflictDoNothingSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(identityAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q identityBulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Identity, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}
@@ -1135,14 +1182,23 @@ func (q identityBulkInsertOnConflictDoUpdateSQL) ToSql() (string, []any, error) 
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join(identityAllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 }
 
-func (q identityBulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Identity, error) {
+func (q identityBulkInsertOnConflictDoUpdateSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join(identityAllColumns, ", ")
+	return query + ";", args, nil
+
+}
+
+func (q identityBulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]Identity, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}

--- a/_example/user.gen.go
+++ b/_example/user.gen.go
@@ -610,17 +610,7 @@ func (s User) Update() userUpdateSQL {
 }
 
 func (q userUpdateSQL) Exec(db sqlla.DB) ([]User, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return nil, err
-	}
-	_, err = db.Exec(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	qq := q.userSQL
-
-	return qq.Select().All(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q userUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]User, error) {

--- a/_example/user.gen.go
+++ b/_example/user.gen.go
@@ -697,6 +697,10 @@ func (q userInsertSQL) ToSql() (string, []any, error) {
 	return query + ";", vs, nil
 }
 
+func (q userInsertSQL) rowsNum() int {
+	return 1
+}
+
 func (q userInsertSQL) userInsertSQLToSql() (string, []any, error) {
 	var err error
 	var s interface{} = User{}
@@ -716,19 +720,7 @@ func (q userInsertSQL) userInsertSQLToSql() (string, []any, error) {
 }
 
 func (q userInsertSQL) Exec(db sqlla.DB) (User, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return User{}, err
-	}
-	result, err := db.Exec(query, args...)
-	if err != nil {
-		return User{}, err
-	}
-	id, err := result.LastInsertId()
-	if err != nil {
-		return User{}, err
-	}
-	return NewUserSQL().Select().PkColumn(id).Single(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q userInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) (User, error) {
@@ -761,6 +753,7 @@ type userDefaultInsertHooker interface {
 }
 
 type userInsertSQLToSqler interface {
+	rowsNum() int
 	userInsertSQLToSql() (string, []any, error)
 }
 
@@ -776,6 +769,10 @@ func (q userSQL) BulkInsert() *userBulkInsertSQL {
 
 func (q *userBulkInsertSQL) Append(iqs ...userInsertSQL) {
 	q.insertSQLs = append(q.insertSQLs, iqs...)
+}
+
+func (q *userBulkInsertSQL) rowsNum() int {
+	return len(q.insertSQLs)
 }
 
 func (q *userBulkInsertSQL) userInsertSQLToSql() (string, []any, error) {

--- a/_example/user_external.gen.go
+++ b/_example/user_external.gen.go
@@ -530,17 +530,7 @@ func (s UserExternal) Update() userExternalUpdateSQL {
 }
 
 func (q userExternalUpdateSQL) Exec(db sqlla.DB) ([]UserExternal, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return nil, err
-	}
-	_, err = db.Exec(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	qq := q.userExternalSQL
-
-	return qq.Select().All(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q userExternalUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]UserExternal, error) {

--- a/_example/user_item.gen.go
+++ b/_example/user_item.gen.go
@@ -565,17 +565,7 @@ func (s UserItem) Update() userItemUpdateSQL {
 }
 
 func (q userItemUpdateSQL) Exec(db sqlla.DB) ([]UserItem, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return nil, err
-	}
-	_, err = db.Exec(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	qq := q.userItemSQL
-
-	return qq.Select().All(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q userItemUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]UserItem, error) {

--- a/_example/user_sns.gen.go
+++ b/_example/user_sns.gen.go
@@ -495,17 +495,7 @@ func (s UserSNS) Update() userSNSUpdateSQL {
 }
 
 func (q userSNSUpdateSQL) Exec(db sqlla.DB) ([]UserSNS, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return nil, err
-	}
-	_, err = db.Exec(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	qq := q.userSNSSQL
-
-	return qq.Select().All(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q userSNSUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]UserSNS, error) {

--- a/_example/user_sns.gen.go
+++ b/_example/user_sns.gen.go
@@ -567,6 +567,10 @@ func (q userSNSInsertSQL) ToSql() (string, []any, error) {
 	return query + ";", vs, nil
 }
 
+func (q userSNSInsertSQL) rowsNum() int {
+	return 1
+}
+
 func (q userSNSInsertSQL) userSNSInsertSQLToSql() (string, []any, error) {
 	var err error
 	var s interface{} = UserSNS{}
@@ -586,19 +590,7 @@ func (q userSNSInsertSQL) userSNSInsertSQLToSql() (string, []any, error) {
 }
 
 func (q userSNSInsertSQL) Exec(db sqlla.DB) (UserSNS, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return UserSNS{}, err
-	}
-	result, err := db.Exec(query, args...)
-	if err != nil {
-		return UserSNS{}, err
-	}
-	id, err := result.LastInsertId()
-	if err != nil {
-		return UserSNS{}, err
-	}
-	return NewUserSNSSQL().Select().PkColumn(id).Single(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q userSNSInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) (UserSNS, error) {
@@ -631,6 +623,7 @@ type userSNSDefaultInsertHooker interface {
 }
 
 type userSNSInsertSQLToSqler interface {
+	rowsNum() int
 	userSNSInsertSQLToSql() (string, []any, error)
 }
 
@@ -646,6 +639,10 @@ func (q userSNSSQL) BulkInsert() *userSNSBulkInsertSQL {
 
 func (q *userSNSBulkInsertSQL) Append(iqs ...userSNSInsertSQL) {
 	q.insertSQLs = append(q.insertSQLs, iqs...)
+}
+
+func (q *userSNSBulkInsertSQL) rowsNum() int {
+	return len(q.insertSQLs)
 }
 
 func (q *userSNSBulkInsertSQL) userSNSInsertSQLToSql() (string, []any, error) {

--- a/template/insert.tmpl
+++ b/template/insert.tmpl
@@ -25,13 +25,20 @@ func (q {{ $camelName }}InsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 			return "", []any{}, err
 	}
-	{{- if eq (dialect) "postgresql" }}
-	columns := strings.Join({{ $camelName }}AllColumns, ", ")
-	return query + " RETURNING " + columns + ";", vs, nil
-	{{- else }}
 	return query + ";", vs, nil
-	{{- end }}
 }
+
+{{ if eq (dialect) "postgresql" }}
+func (q {{ $camelName }}InsertSQL) ToSqlWithReturning() (string, []any, error) {
+	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []any{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join({{ $camelName }}AllColumns, ", ")
+	return query, args, nil
+}
+{{ end }}
 
 func (q {{ $camelName }}InsertSQL) rowsNum() int {
 	return 1
@@ -91,7 +98,7 @@ func (q {{ $camelName }}InsertSQL) Exec(db sqlla.DB) (sql.Result, error) {
 
 {{ if eq (dialect) "postgresql" }}
 func (q {{ $camelName }}InsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ({{ .StructName }}, error) {
-	query, args, err := q.ToSql()
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return {{ .StructName }}{}, err
 	}
@@ -257,17 +264,22 @@ func (q *{{ $camelName }}BulkInsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 			return "", []any{}, err
 	}
-	{{- if eq (dialect) "postgresql" }}
-	columns := strings.Join({{ $camelName }}AllColumns, ", ")
-	return query + " RETURNING " + columns + ";", vs, nil
-	{{- else }}
 	return query + ";", vs, nil
-	{{- end }}
 }
 
 {{- if eq (dialect) "postgresql" }}
-func (q *{{ $camelName }}BulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {
+func (q *{{ $camelName }}BulkInsertSQL) ToSqlWithReturning() (string, []any, error) {
 	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []any{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join({{ $camelName }}AllColumns, ", ")
+	return query + ";", args, nil
+}
+
+func (q *{{ $camelName }}BulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}

--- a/template/insert.tmpl
+++ b/template/insert.tmpl
@@ -25,11 +25,16 @@ func (q {{ $camelName }}InsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 			return "", []any{}, err
 	}
-	{{- if and .HasPk (eq (dialect) "postgresql") }}
-	return query + " RETURNING " + {{ cquoteby .PkColumn.Name }} + ";", vs, nil
+	{{- if eq (dialect) "postgresql" }}
+	columns := strings.Join({{ $camelName }}AllColumns, ", ")
+	return query + " RETURNING " + columns + ";", vs, nil
 	{{- else }}
 	return query + ";", vs, nil
 	{{- end }}
+}
+
+func (q {{ $camelName }}InsertSQL) rowsNum() int {
+	return 1
 }
 
 {{ if eq (dialect) "mysql" }}
@@ -81,40 +86,32 @@ func (q {{ $camelName }}InsertSQL) Exec(db sqlla.DB) ({{ .StructName }}, error) 
 {{- else -}}
 func (q {{ $camelName }}InsertSQL) Exec(db sqlla.DB) (sql.Result, error) {
 {{- end }}
-	query, args, err := q.ToSql()
-	if err != nil {
-		{{ if .HasPk -}}
-		return {{ .StructName }}{}, err
-		{{- else }}
-		return nil, err
-		{{- end }}
-	}
-	{{- if not .HasPk }}
-	result, err := db.Exec(query, args...)
-	return result, err
-	{{- else }}
-	{{- if eq (dialect) "mysql" }}
-	result, err := db.Exec(query, args...)
-	if err != nil {
-		return {{ .StructName }}{}, err
-	}
-	id, err := result.LastInsertId()
-	if err != nil {
-		return {{ .StructName }}{}, err
-	}
-	return {{ $constructor }}().Select().PkColumn(id).Single(db)
-	{{- end }}
-	{{- if eq (dialect) "postgresql" }}
-	row := db.QueryRow(query, args...)
-	var pk {{ .PkColumn.TypeName }}
-	if err := row.Scan(&pk); err != nil {
-		return {{ .StructName }}{}, err
-	}
-	return {{ $constructor }}().Select().{{ .PkColumn.MethodName }}(pk).Single(db)
-	{{- end }}
-	{{- end }}
+	return q.ExecContext(context.Background(), db)
 }
 
+{{ if eq (dialect) "postgresql" }}
+func (q {{ $camelName }}InsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ({{ .StructName }}, error) {
+	query, args, err := q.ToSql()
+	if err != nil {
+		return {{ .StructName }}{}, err
+	}
+	row := db.QueryRowContext(ctx, query, args...)
+	result, err := {{ $constructor }}().Select().Scan(row)
+	if err != nil {
+		return {{ .StructName }}{}, err
+	}
+	return result, nil
+}
+
+func (q {{ $camelName }}InsertSQL) ExecContextWithoutSelect(ctx context.Context, db sqlla.DB) (sql.Result, error) {
+	query, args, err := q.ToSql()
+	if err != nil {
+		return nil, err
+	}
+	result, err := db.ExecContext(ctx, query, args...)
+	return result, err
+}
+{{ else }}
 {{ if .HasPk -}}
 func (q {{ $camelName }}InsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ({{ .StructName }}, error) {
 {{- else -}}
@@ -132,7 +129,6 @@ func (q {{ $camelName }}InsertSQL) ExecContext(ctx context.Context, db sqlla.DB)
 	result, err := db.ExecContext(ctx, query, args...)
 	return result, err
 	{{- else }}
-	{{- if eq (dialect) "mysql" }}
 	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return {{ .StructName }}{}, err
@@ -142,15 +138,6 @@ func (q {{ $camelName }}InsertSQL) ExecContext(ctx context.Context, db sqlla.DB)
 		return {{ .StructName }}{}, err
 	}
 	return {{ $constructor }}().Select().PkColumn(id).SingleContext(ctx, db)
-	{{- end }}
-	{{- if eq (dialect) "postgresql" }}
-	row := db.QueryRowContext(ctx, query, args...)
-	var pk {{ .PkColumn.TypeName }}
-	if err := row.Scan(&pk); err != nil {
-		return {{ .StructName }}{}, err
-	}
-	return {{ $constructor }}().Select().{{ .PkColumn.MethodName }}(pk).SingleContext(ctx, db)
-	{{- end }}
 	{{- end }}
 }
 
@@ -164,12 +151,14 @@ func (q {{ $camelName }}InsertSQL) ExecContextWithoutSelect(ctx context.Context,
 	return result, err
 }
 {{- end }}
+{{- end }}
 
 type {{ $camelName }}DefaultInsertHooker interface {
 	DefaultInsertHook({{ $camelName }}InsertSQL) ({{ $camelName }}InsertSQL, error)
 }
 
 type {{ $camelName }}InsertSQLToSqler interface {
+	rowsNum() int
 	{{- if eq (dialect) "mysql" }}
 	{{ $camelName }}InsertSQLToSql() (string, []any, error)
 	{{- end }}
@@ -190,6 +179,10 @@ func (q {{ $camelName }}SQL) BulkInsert() *{{ $camelName }}BulkInsertSQL {
 
 func (q *{{ $camelName }}BulkInsertSQL) Append(iqs ...{{ $camelName }}InsertSQL) {
 	q.insertSQLs = append(q.insertSQLs, iqs...)
+}
+
+func (q *{{ $camelName }}BulkInsertSQL) rowsNum() int {
+	return len(q.insertSQLs)
 }
 
 {{ if eq (dialect) "mysql" }}
@@ -264,44 +257,37 @@ func (q *{{ $camelName }}BulkInsertSQL) ToSql() (string, []any, error) {
 	if err != nil {
 			return "", []any{}, err
 	}
-	{{- if and .HasPk (eq (dialect) "postgresql") }}
-	return query + " RETURNING " + {{ cquoteby .PkColumn.Name }} + ";", vs, nil
+	{{- if eq (dialect) "postgresql" }}
+	columns := strings.Join({{ $camelName }}AllColumns, ", ")
+	return query + " RETURNING " + columns + ";", vs, nil
 	{{- else }}
 	return query + ";", vs, nil
 	{{- end }}
 }
 
-{{- if and .HasPk (eq (dialect) "postgresql") }}
+{{- if eq (dialect) "postgresql" }}
 func (q *{{ $camelName }}BulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {
-{{- else }}
-func (q *{{ $camelName }}BulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) (sql.Result, error) {
-{{- end }}
 	query, args, err := q.ToSql()
 	if err != nil {
 		return nil, err
 	}
-	{{- if and .HasPk (eq (dialect) "postgresql") }}
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	pks := make([]{{ .PkColumn.TypeName }}, 0, len(q.insertSQLs))
+	results := make([]{{ .StructName }}, 0, len(q.insertSQLs))
+	sel := {{ $constructor }}().Select()
 	for rows.Next() {
-		var pk {{ .PkColumn.TypeName }}
-		if err := rows.Scan(&pk); err != nil {
+		result, err := sel.Scan(rows)
+		if err != nil {
 			return nil, err
 		}
-		pks = append(pks, pk)
+		results = append(results, result)
 	}
-	return {{ $constructor }}().Select().{{ .PkColumn.MethodName }}In(pks...).AllContext(ctx, db)
-	{{- else }}
-	result, err := db.ExecContext(ctx, query, args...)
-	return result, err
-	{{- end }}
+	return results, nil
 }
 
-{{- if and .HasPk (eq (dialect) "postgresql") }}
 func (q *{{ $camelName }}BulkInsertSQL) ExecContextWithoutSelect(ctx context.Context, db sqlla.DB) (sql.Result, error) {
 	query, args, err := q.ToSql()
 	if err != nil {
@@ -311,6 +297,18 @@ func (q *{{ $camelName }}BulkInsertSQL) ExecContextWithoutSelect(ctx context.Con
 	return result, err
 }
 {{- end }}
+
+{{- if eq (dialect) "mysql" }}
+func (q *{{ $camelName }}BulkInsertSQL) ExecContext(ctx context.Context, db sqlla.DB) (sql.Result, error) {
+	query, args, err := q.ToSql()
+	if err != nil {
+		return nil, err
+	}
+	result, err := db.ExecContext(ctx, query, args...)
+	return result, err
+}
+{{- end }}
+
 
 {{- if eq (dialect) "mysql" }}
 {{ template "InsertMySQL" . }}

--- a/template/insert_postgresql.tmpl
+++ b/template/insert_postgresql.tmpl
@@ -1,17 +1,17 @@
-{{ define "InsertPostgreSQL.ExecContextHasPkSingle" }}
+{{ define "InsertPostgreSQL.ExecContextSingle" }}
 {{- $constructor := printf "New%sSQL" (.Name | toCamel) -}}
 	query, args, err := q.ToSql()
 	if err != nil {
 		return {{ .StructName }}{}, err
 	}
 	row := db.QueryRowContext(ctx, query, args...)
-	var pk {{ .PkColumn.TypeName }}
-	if err := row.Scan(&pk); err != nil {
+	result, err := {{ $constructor }}().Select().Scan(row)
+	if err != nil {
 		return {{ .StructName }}{}, err
 	}
-	return {{ $constructor }}().Select().{{ .PkColumn.MethodName }}(pk).SingleContext(ctx, db)
+	return result, nil
 {{ end }}
-{{ define "InsertPostgreSQL.ExecContextHasPkAll" }}
+{{ define "InsertPostgreSQL.ExecContextAll" }}
 {{- $constructor := printf "New%sSQL" (.Name | toCamel) -}}
 	query, args, err := q.ToSql()
 	if err != nil {
@@ -22,16 +22,17 @@
 		return nil, err
 	}
 	defer rows.Close()
-	pks := make([]{{ .PkColumn.TypeName }}, 0)
+	results := make([]{{ .StructName }}, 0, q.insertSQL.rowsNum())
+	sel := {{ $constructor }}().Select()
 	for rows.Next() {
-		var pk {{ .PkColumn.TypeName }}
-		if err := rows.Scan(&pk); err != nil {
+		result, err := sel.Scan(rows)
+		if err != nil {
 			return nil, err
 		}
-		pks = append(pks, pk)
+		results = append(results, result)
 	}
 
-	return {{ $constructor }}().Select().{{ .PkColumn.MethodName }}In(pks...).AllContext(ctx, db)
+	return results, nil
 {{ end }}
 {{ define "InsertPostgreSQL.ExecContextWithoutSelect" }}
 	query, args, err := q.ToSql()
@@ -47,10 +48,8 @@
 	if err != nil {
 		return "", nil, err
 	}
-	query += " ON CONFLICT DO NOTHING"
-	{{- if .HasPk }}
-	query += " RETURNING " + {{ cquoteby .PkColumn.Name }}
-	{{- end }}
+	columns := strings.Join({{ $camelName }}AllColumns, ", ")
+	query += " ON CONFLICT DO NOTHING" + " RETURNING " + columns
 	return query + ";", vs, nil
 {{ end }}
 {{ define "InsertPostgreSQL.DoUpdateToSql" }}
@@ -75,9 +74,8 @@
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	{{- if .HasPk }}
-	query += " RETURNING " + {{ cquoteby .PkColumn.Name }}
-	{{- end }}
+	columns := strings.Join({{ $camelName }}AllColumns, ", ")
+	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 {{ end }}
@@ -100,19 +98,13 @@ func (q {{ $camelName }}InsertOnConflictDoNothingSQL) ToSql() (string, []any, er
 {{ template "InsertPostgreSQL.DoNothingToSql" . }}
 }
 
-{{ if .HasPk -}}
 func (q {{ $camelName }}InsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ({{ .StructName }}, error) {
-{{ template "InsertPostgreSQL.ExecContextHasPkSingle" . }}
+{{ template "InsertPostgreSQL.ExecContextSingle" . }}
 }
 
 func (q {{ $camelName }}InsertOnConflictDoNothingSQL) ExecContextWithoutSelect(ctx context.Context, db sqlla.DB) (sql.Result, error) {
 {{ template "InsertPostgreSQL.ExecContextWithoutSelect" . }}
 }
-{{- else -}}
-func (q {{ $camelName }}InsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) (sql.Result, error) {
-{{ template "InsertPostgreSQL.ExecContextWithoutSelect" . }}
-}
-{{- end }}
 
 type {{ $camelName }}InsertOnConflictDoUpdateSQL struct {
 	insertSQL {{ $camelName }}InsertSQLToSqler
@@ -151,26 +143,19 @@ func (q {{ $camelName }}InsertOnConflictDoUpdateSQL) ToSql() (string, []any, err
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	{{- if .HasPk }}
-	query += " RETURNING " + {{ cquoteby .PkColumn.Name }}
-	{{- end }}
+	columns := strings.Join({{ $camelName }}AllColumns, ", ")
+	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 }
 
-{{ if .HasPk -}}
 func (q {{ $camelName }}InsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ({{ .StructName }}, error) {
-{{ template "InsertPostgreSQL.ExecContextHasPkSingle" . }}
+{{ template "InsertPostgreSQL.ExecContextSingle" . }}
 }
 
 func (q {{ $camelName }}InsertOnConflictDoUpdateSQL) ExecContextWithoutSelect(ctx context.Context, db sqlla.DB) (sql.Result, error) {
 {{ template "InsertPostgreSQL.ExecContextWithoutSelect" . }}
 }
-{{- else -}}
-func (q {{ $camelName }}InsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (sql.Result, error) {
-{{ template "InsertPostgreSQL.ExecContextWithoutSelect" . }}
-}
-{{- end }}
 
 type {{ $camelName }}DefaultInsertOnConflictDoUpdateHooker interface {
 	DefaultInsertOnConflictDoUpdateHook({{ $camelName }}InsertOnConflictDoUpdateSQL) ({{ $camelName }}InsertOnConflictDoUpdateSQL, error)
@@ -190,19 +175,13 @@ func (q {{ $camelName }}BulkInsertOnConflictDoNothingSQL) ToSql() (string, []any
 {{ template "InsertPostgreSQL.DoNothingToSql" . }}
 }
 
-{{ if .HasPk -}}
 func (q {{ $camelName }}BulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {
-{{ template "InsertPostgreSQL.ExecContextHasPkAll" . }}
+{{ template "InsertPostgreSQL.ExecContextAll" . }}
 }
 
 func (q {{ $camelName }}BulkInsertOnConflictDoNothingSQL) ExecContextWithoutSelect(ctx context.Context, db sqlla.DB) (sql.Result, error) {
 {{ template "InsertPostgreSQL.ExecContextWithoutSelect" . }}
 }
-{{- else -}}
-func (q {{ $camelName }}BulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) (sql.Result, error) {
-{{ template "InsertPostgreSQL.ExecContextWithoutSelect" . }}
-}
-{{- end }}
 
 type {{ $camelName }}BulkInsertOnConflictDoUpdateSQL struct {
 	insertSQL {{ $camelName }}InsertSQLToSqler
@@ -248,25 +227,18 @@ func (q {{ $camelName }}BulkInsertOnConflictDoUpdateSQL) ToSql() (string, []any,
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	{{- if .HasPk }}
-	query += " RETURNING " + {{ cquoteby .PkColumn.Name }}
-	{{- end }}
+	columns := strings.Join({{ $camelName }}AllColumns, ", ")
+	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
 }
 
-{{ if .HasPk -}}
 func (q {{ $camelName }}BulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {
-{{ template "InsertPostgreSQL.ExecContextHasPkAll" . }}
+{{ template "InsertPostgreSQL.ExecContextAll" . }}
 }
 
 func (q {{ $camelName }}BulkInsertOnConflictDoUpdateSQL) ExecContextWithoutSelect(ctx context.Context, db sqlla.DB) (sql.Result, error) {
 {{ template "InsertPostgreSQL.ExecContextWithoutSelect" . }}
 }
-{{- else -}}
-func (q {{ $camelName }}BulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (sql.Result, error) {
-{{ template "InsertPostgreSQL.ExecContextWithoutSelect" . }}
-}
-{{- end }}
 
 {{ end }}

--- a/template/insert_postgresql.tmpl
+++ b/template/insert_postgresql.tmpl
@@ -1,6 +1,6 @@
 {{ define "InsertPostgreSQL.ExecContextSingle" }}
 {{- $constructor := printf "New%sSQL" (.Name | toCamel) -}}
-	query, args, err := q.ToSql()
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return {{ .StructName }}{}, err
 	}
@@ -13,7 +13,7 @@
 {{ end }}
 {{ define "InsertPostgreSQL.ExecContextAll" }}
 {{- $constructor := printf "New%sSQL" (.Name | toCamel) -}}
-	query, args, err := q.ToSql()
+	query, args, err := q.ToSqlWithReturning()
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +48,7 @@
 	if err != nil {
 		return "", nil, err
 	}
-	columns := strings.Join({{ $camelName }}AllColumns, ", ")
-	query += " ON CONFLICT DO NOTHING" + " RETURNING " + columns
+	query += " ON CONFLICT DO NOTHING"
 	return query + ";", vs, nil
 {{ end }}
 {{ define "InsertPostgreSQL.DoUpdateToSql" }}
@@ -74,10 +73,18 @@
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join({{ $camelName }}AllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
+{{ end }}
+{{ define "InsertPostgreSQL.ToSqlWithReturning" }}
+{{- $camelName := .Name | toCamel | untitle -}}
+	query, args, err := q.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join({{ $camelName }}AllColumns, ", ")
+	return query + ";", args, nil
 {{ end }}
 
 {{ define "InsertPostgreSQL" }}
@@ -96,6 +103,10 @@ func (q {{ $camelName }}InsertSQL) OnConflictDoNothing() {{ $camelName }}InsertO
 
 func (q {{ $camelName }}InsertOnConflictDoNothingSQL) ToSql() (string, []any, error) {
 {{ template "InsertPostgreSQL.DoNothingToSql" . }}
+}
+
+func (q {{ $camelName }}InsertOnConflictDoNothingSQL) ToSqlWithReturning() (string, []any, error) {
+{{ template "InsertPostgreSQL.ToSqlWithReturning" . }}
 }
 
 func (q {{ $camelName }}InsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ({{ .StructName }}, error) {
@@ -143,10 +154,12 @@ func (q {{ $camelName }}InsertOnConflictDoUpdateSQL) ToSql() (string, []any, err
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join({{ $camelName }}AllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
+}
+
+func (q {{ $camelName }}InsertOnConflictDoUpdateSQL) ToSqlWithReturning() (string, []any, error) {
+{{ template "InsertPostgreSQL.ToSqlWithReturning" . }}
 }
 
 func (q {{ $camelName }}InsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ({{ .StructName }}, error) {
@@ -173,6 +186,10 @@ func (q *{{ $camelName }}BulkInsertSQL) OnConflictDoNothing() {{ $camelName }}Bu
 
 func (q {{ $camelName }}BulkInsertOnConflictDoNothingSQL) ToSql() (string, []any, error) {
 {{ template "InsertPostgreSQL.DoNothingToSql" . }}
+}
+
+func (q {{ $camelName }}BulkInsertOnConflictDoNothingSQL) ToSqlWithReturning() (string, []any, error) {
+{{ template "InsertPostgreSQL.ToSqlWithReturning" . }}
 }
 
 func (q {{ $camelName }}BulkInsertOnConflictDoNothingSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {
@@ -227,10 +244,12 @@ func (q {{ $camelName }}BulkInsertOnConflictDoUpdateSQL) ToSql() (string, []any,
 	}
 	query += " ON CONFLICT (" + q.target + ") DO UPDATE SET" + os
 	vs = append(vs, ovs...)
-	columns := strings.Join({{ $camelName }}AllColumns, ", ")
-	query += " RETURNING " + columns
 
 	return query + ";", vs, nil
+}
+
+func (q {{ $camelName }}BulkInsertOnConflictDoUpdateSQL) ToSqlWithReturning() (string, []any, error) {
+{{ template "InsertPostgreSQL.ToSqlWithReturning" . }}
 }
 
 func (q {{ $camelName }}BulkInsertOnConflictDoUpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {

--- a/template/update.tmpl
+++ b/template/update.tmpl
@@ -50,23 +50,56 @@ func (q {{ $camelName }}UpdateSQL) ToSql() (string, []interface{}, error) {
 	return query + ";", append(svs, wvs...), nil
 }
 
+{{- if eq (dialect) "postgresql" }}
+func (q {{ $camelName }}UpdateSQL) ToSqlWithReturning() (string, []interface{}, error) {
+	query, args, err := q.ToSql()
+	if err != nil {
+		return "", []interface{}{}, err
+	}
+	query = strings.TrimSuffix(query, ";")
+	query += " RETURNING " + strings.Join({{ $camelName }}AllColumns, ", ")
+	return query + ";", args, nil
+}
+
+func (s {{ .StructName }}) Update() {{ $camelName }}UpdateSQL {
+	return {{ $constructor }}().Update().Where{{ .PkColumn.Name | toCamel | title }}(s.{{ .PkColumn.FieldName }})
+}
+
+func (q {{ $camelName }}UpdateSQL) Exec(db sqlla.DB) ([]{{ .StructName }}, error) {
+	return q.ExecContext(context.Background(), db)
+}
+
+func (q {{ $camelName }}UpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {
+	query, args, err := q.ToSqlWithReturning()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]{{ .StructName }}, 0, 1)
+	defer rows.Close()
+	sel := {{ $constructor }}().Select()
+	for rows.Next() {
+		result, err := sel.Scan(rows)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+{{- end }}
+{{- if eq (dialect) "mysql" }}
 {{- if .HasPk }}
 func (s {{ .StructName }}) Update() {{ $camelName }}UpdateSQL {
 	return {{ $constructor }}().Update().Where{{ .PkColumn.Name | toCamel | title }}(s.{{ .PkColumn.FieldName }})
 }
 
 func (q {{ $camelName }}UpdateSQL) Exec(db sqlla.DB) ([]{{ .StructName }}, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return nil, err
-	}
-	_, err = db.Exec(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	qq := q.{{ $camelName }}SQL
-
-	return qq.Select().All(db)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q {{ $camelName }}UpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) ([]{{ .StructName }}, error) {
@@ -84,11 +117,7 @@ func (q {{ $camelName }}UpdateSQL) ExecContext(ctx context.Context, db sqlla.DB)
 }
 {{- else }}
 func (q {{ $camelName }}UpdateSQL) Exec(db sqlla.DB) (sql.Result, error) {
-	query, args, err := q.ToSql()
-	if err != nil {
-		return nil, err
-	}
-	return db.Exec(query, args...)
+	return q.ExecContext(context.Background(), db)
 }
 
 func (q {{ $camelName }}UpdateSQL) ExecContext(ctx context.Context, db sqlla.DB) (sql.Result, error) {
@@ -98,6 +127,7 @@ func (q {{ $camelName }}UpdateSQL) ExecContext(ctx context.Context, db sqlla.DB)
 	}
 	return db.ExecContext(ctx, query, args...)
 }
+{{- end }}
 {{- end }}
 
 type {{ $camelName }}DefaultUpdateHooker interface {


### PR DESCRIPTION
## Summary

This pull request updates the PostgreSQL dialect of the query builder to improve how rows are retrieved after `INSERT` and `UPDATE` operations. Previously, INSERT and UPDATE queries would use the `RETURNING` clause to get the primary key(s), then issue a secondary `SELECT` statement to fetch the entire row from the database. With these changes, all columns are now fetched directly using `RETURNING *` (or the necessary column list) in the INSERT/UPDATE statement itself, eliminating the need for a second query.

## Motivation

The previous implementation introduced unnecessary overhead by always performing a secondary fetch to retrieve full row data after modifications. By leveraging PostgreSQL's `RETURNING` clause to obtain all columns in a single query, we reduce round-trips to the database and ensure that the returned row reflects the actual state after the write operation. This also avoids potential race conditions where data might change between the write and the follow-up select.

## Details

- **INSERT queries:**
  - Instead of using `RETURNING` only for primary keys and selecting the full row with another query, the code now uses `RETURNING` to fetch all columns.
  - Bulk insert and insert-on-conflict code paths are also updated to use these semantics.
  - APIs and generated code now return full row data directly.
- **UPDATE queries:**
  - UPDATE operations now return the modified rows using `RETURNING` for all queried columns, removing the need for a select-after-update.
- **API changes (breaking):**
  - The existing `ToSql` method for INSERT no longer automatically appends a `RETURNING` clause.
  - A new `ToSqlWithReturning` method is introduced for cases where a `RETURNING` clause is needed (backward compatible with old behavior).
  - Test cases updated to reflect the new result structure for INSERT/UPDATE statements.